### PR TITLE
RDM-1831 Hide and show condition for a tab and tab field on a case view

### DIFF
--- a/domain/src/test/java/uk/gov/hmcts/ccd/definition/store/domain/validation/displaygroup/TabShowConditionValidatorImplTest.java
+++ b/domain/src/test/java/uk/gov/hmcts/ccd/definition/store/domain/validation/displaygroup/TabShowConditionValidatorImplTest.java
@@ -1,10 +1,9 @@
 package uk.gov.hmcts.ccd.definition.store.domain.validation.displaygroup;
 
 import org.assertj.core.util.Lists;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.ccd.definition.store.domain.showcondition.InvalidShowConditionException;
@@ -31,7 +30,7 @@ public class TabShowConditionValidatorImplTest {
     DisplayGroupEntity displayGroup;
     List<DisplayGroupEntity> allTabDisplayGroups;
 
-    @BeforeEach
+    @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         testObj = new TabShowConditionValidatorImpl(mockShowConditionParser);
@@ -39,365 +38,364 @@ public class TabShowConditionValidatorImplTest {
         allTabDisplayGroups = Lists.newArrayList();
     }
 
-    @Nested
-    class TabFieldShowCondition {
+//    @Nested
+//    class TabFieldShowCondition {
 
-        @Test
-        @DisplayName("should not execute when tab field show condition is empty")
-        public void shouldNotExecuteWhenShowConditionIsEmpty() throws InvalidShowConditionException {
+    @Test
+    @DisplayName("should not execute when tab field show condition is empty")
+    public void shouldNotExecuteWhenShowConditionIsEmpty() throws InvalidShowConditionException {
 
-            displayGroup.setType(DisplayGroupType.TAB);
-            DisplayGroupCaseFieldEntity displayGroupCaseFieldEntity = new DisplayGroupCaseFieldEntity();
-            displayGroupCaseFieldEntity.setShowCondition(null);
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseFieldEntity);
+        displayGroup.setType(DisplayGroupType.TAB);
+        DisplayGroupCaseFieldEntity displayGroupCaseFieldEntity = new DisplayGroupCaseFieldEntity();
+        displayGroupCaseFieldEntity.setShowCondition(null);
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseFieldEntity);
 
-            testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
+        testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
 
-            verify(mockShowConditionParser, never()).parseShowCondition(anyString());
-        }
-
-        @Test
-        @DisplayName("should not execute when tab field show condition is blank")
-        public void shouldNotExecuteWhenShowConditionIsBlank() throws InvalidShowConditionException {
-
-            DisplayGroupCaseFieldEntity displayGroupCaseFieldEntity = new DisplayGroupCaseFieldEntity();
-            displayGroupCaseFieldEntity.setShowCondition("");
-            displayGroup.setType(DisplayGroupType.TAB);
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseFieldEntity);
-
-            testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
-
-            verify(mockShowConditionParser, never()).parseShowCondition(anyString());
-        }
-
-        @Test
-        @DisplayName("should not execute when tab show type is not tab")
-        public void shouldNotExecuteWhenShowTypeIsNotTab() throws InvalidShowConditionException {
-
-            DisplayGroupCaseFieldEntity displayGroupCaseFieldEntity = new DisplayGroupCaseFieldEntity();
-            displayGroupCaseFieldEntity.setShowCondition("someShowCondition");
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseFieldEntity);
-            displayGroup.setType(DisplayGroupType.PAGE);
-
-            testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
-
-            verify(mockShowConditionParser, never()).parseShowCondition(anyString());
-        }
-
-        @Test
-        @DisplayName("should return no errors when tab field referenced field in other tab")
-        public void returnsNoValidationErrorsOnSuccessWhenReferencedFieldInOtherTab() throws InvalidShowConditionException {
-
-            displayGroup.setType(DisplayGroupType.TAB);
-            CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
-            caseTypeEntity.setReference("SimpleType");
-            displayGroup.setCaseType(caseTypeEntity);
-            DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
-            displayGroupCaseField.setShowCondition("someShowCondition");
-            CaseFieldEntity caseField = new CaseFieldEntity();
-            caseField.setReference("thisField");
-            displayGroupCaseField.setCaseField(caseField);
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
-            allTabDisplayGroups.add(displayGroup);
-
-            DisplayGroupCaseFieldEntity displayGroupCaseFieldOther = new DisplayGroupCaseFieldEntity();
-            CaseFieldEntity caseFieldOther = new CaseFieldEntity();
-            caseFieldOther.setReference("otherField");
-            displayGroupCaseFieldOther.setCaseField(caseFieldOther);
-            DisplayGroupEntity otherTabDisplayGroup = new DisplayGroupEntity();
-            otherTabDisplayGroup.setType(DisplayGroupType.TAB);
-            otherTabDisplayGroup.addDisplayGroupCaseField(displayGroupCaseFieldOther);
-            otherTabDisplayGroup.setCaseType(caseTypeEntity);
-            allTabDisplayGroups.add(otherTabDisplayGroup);
-
-            ShowCondition validParsedShowCondition = new ShowCondition.Builder().showConditionExpression("parsedSC").field("otherField").build();
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenReturn(validParsedShowCondition);
-
-            ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
-
-            assertThat(result.isValid(), is(true));
-        }
-
-        @Test
-        @DisplayName("should return no errors when tab field referenced field in this tab")
-        public void returnsNoValidationErrorsOnSuccessWhenReferencedFieldInThisTab() throws InvalidShowConditionException {
-
-            displayGroup.setType(DisplayGroupType.TAB);
-            CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
-            caseTypeEntity.setReference("SimpleType");
-            displayGroup.setCaseType(caseTypeEntity);
-
-            DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
-            CaseFieldEntity caseField = new CaseFieldEntity();
-            caseField.setReference("field");
-            displayGroupCaseField.setCaseField(caseField);
-            displayGroupCaseField.setShowCondition("someShowCondition");
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
-            allTabDisplayGroups.add(displayGroup);
-
-            ShowCondition validParsedShowCondition = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenReturn(validParsedShowCondition);
-
-            ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
-
-            assertThat(result.isValid(), is(true));
-        }
-
-        @Test
-        @DisplayName("should fail when unable to parse show condition for tab field")
-        public void returnsDisplayGroupInvalidShowConditionErrorWhenUnableToParseShowCondition() throws InvalidShowConditionException {
-
-            displayGroup.setType(DisplayGroupType.TAB);
-            DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
-            displayGroupCaseField.setShowCondition("someShowCondition");
-            CaseFieldEntity caseField = new CaseFieldEntity();
-            caseField.setReference("field");
-            displayGroupCaseField.setCaseField(caseField);
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
-
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenThrow(new InvalidShowConditionException("someShowCondition"));
-
-            ValidationResult result = testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
-
-            assertThat(result.isValid(), is(false));
-            assertThat(result.getValidationErrors(), hasSize(1));
-            assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabFieldShowCondition.class));
-        }
-
-        @Test
-        @DisplayName("should fail when tab field show condition references invalid field from same tab")
-        public void returnsDisplayGroupInvalidShowConditionFieldWhenShowConditionReferencesInvalidFieldFromSameTab() throws InvalidShowConditionException {
-
-            displayGroup.setType(DisplayGroupType.TAB);
-            CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
-            caseTypeEntity.setReference("SimpleType");
-            displayGroup.setCaseType(caseTypeEntity);
-
-            DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
-            CaseFieldEntity caseField = new CaseFieldEntity();
-            caseField.setReference("otherField");
-            displayGroupCaseField.setCaseField(caseField);
-            displayGroupCaseField.setShowCondition("someShowCondition");
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
-            allTabDisplayGroups.add(displayGroup);
-
-            ShowCondition sc = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenReturn(sc);
-
-            ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
-
-            assertThat(result.isValid(), is(false));
-            assertThat(result.getValidationErrors(), hasSize(1));
-            assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabFieldShowCondition.class));
-        }
-
-
-        @Test
-        @DisplayName("should fail when tab field show condition references invalid field from other tab")
-        public void returnsDisplayGroupInvalidShowConditionFieldWhenShowConditionReferencesInvalidFieldFromOtherTab() throws InvalidShowConditionException {
-
-            displayGroup.setType(DisplayGroupType.TAB);
-            CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
-            caseTypeEntity.setReference("SimpleType");
-            displayGroup.setCaseType(caseTypeEntity);
-            DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
-            displayGroupCaseField.setShowCondition("someShowCondition");
-            CaseFieldEntity caseField = new CaseFieldEntity();
-            caseField.setReference("thisField");
-            displayGroupCaseField.setCaseField(caseField);
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
-
-            DisplayGroupCaseFieldEntity displayGroupCaseFieldOther = new DisplayGroupCaseFieldEntity();
-            CaseFieldEntity caseFieldOther = new CaseFieldEntity();
-            caseFieldOther.setReference("otherField");
-            displayGroupCaseFieldOther.setCaseField(caseFieldOther);
-            DisplayGroupEntity otherTabDisplayGroup = new DisplayGroupEntity();
-            otherTabDisplayGroup.setType(DisplayGroupType.TAB);
-            otherTabDisplayGroup.addDisplayGroupCaseField(displayGroupCaseFieldOther);
-            otherTabDisplayGroup.setCaseType(caseTypeEntity);
-            allTabDisplayGroups.add(otherTabDisplayGroup);
-
-            ShowCondition sc = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenReturn(sc);
-
-            ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
-
-            assertThat(result.isValid(), is(false));
-            assertThat(result.getValidationErrors(), hasSize(1));
-            assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabFieldShowCondition.class));
-        }
+        verify(mockShowConditionParser, never()).parseShowCondition(anyString());
     }
 
-    @Nested
-    class TabShowCondition {
+    @Test
+//    @DisplayName("should not execute when tab field show condition is blank")
+    public void TabFieldShowCondition_shouldNotExecuteWhenShowConditionIsBlank() throws InvalidShowConditionException {
 
-        @Test
-        @DisplayName("should not execute when tab show condition is empty")
-        public void shouldNotExecuteWhenShowConditionIsEmpty() throws InvalidShowConditionException {
+        DisplayGroupCaseFieldEntity displayGroupCaseFieldEntity = new DisplayGroupCaseFieldEntity();
+        displayGroupCaseFieldEntity.setShowCondition("");
+        displayGroup.setType(DisplayGroupType.TAB);
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseFieldEntity);
 
-            displayGroup.setShowCondition(null);
-            displayGroup.setType(DisplayGroupType.TAB);
+        testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
 
-            testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
-
-            verify(mockShowConditionParser, never()).parseShowCondition(anyString());
-        }
-
-        @Test
-        @DisplayName("should not execute when tab show condition is blank")
-        public void shouldNotExecuteWhenShowConditionIsBlank() throws InvalidShowConditionException {
-
-            displayGroup.setShowCondition("");
-            displayGroup.setType(DisplayGroupType.TAB);
-
-            testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
-
-            verify(mockShowConditionParser, never()).parseShowCondition(anyString());
-        }
-
-        @Test
-        @DisplayName("should not execute when tab show type is not tab")
-        public void shouldNotExecuteWhenShowTypeIsNotTab() throws InvalidShowConditionException {
-
-            displayGroup.setShowCondition("someShowCondition");
-            displayGroup.setType(DisplayGroupType.PAGE);
-
-            testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
-
-            verify(mockShowConditionParser, never()).parseShowCondition(anyString());
-        }
-
-        @Test
-        @DisplayName("should return no errors when tab referenced field in other tab")
-        public void returnsNoValidationErrorsOnSuccessWhenReferencedFieldInOtherTab() throws InvalidShowConditionException {
-
-            displayGroup.setShowCondition("someShowCondition");
-            displayGroup.setType(DisplayGroupType.TAB);
-            CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
-            caseTypeEntity.setReference("SimpleType");
-            displayGroup.setCaseType(caseTypeEntity);
-
-            DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
-            CaseFieldEntity caseField = new CaseFieldEntity();
-            caseField.setReference("field");
-            displayGroupCaseField.setCaseField(caseField);
-            DisplayGroupEntity otherTabDisplayGroup = new DisplayGroupEntity();
-            otherTabDisplayGroup.setType(DisplayGroupType.TAB);
-            otherTabDisplayGroup.addDisplayGroupCaseField(displayGroupCaseField);
-            otherTabDisplayGroup.setCaseType(caseTypeEntity);
-            allTabDisplayGroups.add(otherTabDisplayGroup);
-
-            ShowCondition validParsedShowCondition = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenReturn(validParsedShowCondition);
-
-            ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
-
-            assertThat(result.isValid(), is(true));
-        }
-
-        @Test
-        @DisplayName("should return no errors when tab referenced field in this tab")
-        public void returnsNoValidationErrorsOnSuccessWhenReferencedFieldInThisTab() throws InvalidShowConditionException {
-
-            displayGroup.setShowCondition("someShowCondition");
-            displayGroup.setType(DisplayGroupType.TAB);
-            CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
-            caseTypeEntity.setReference("SimpleType");
-            displayGroup.setCaseType(caseTypeEntity);
-
-            DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
-            CaseFieldEntity caseField = new CaseFieldEntity();
-            caseField.setReference("field");
-            displayGroupCaseField.setCaseField(caseField);
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
-            allTabDisplayGroups.add(displayGroup);
-
-            ShowCondition validParsedShowCondition = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenReturn(validParsedShowCondition);
-
-            ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
-
-            assertThat(result.isValid(), is(true));
-        }
-
-        @Test
-        @DisplayName("should fail when unable to parse show condition for tab")
-        public void returnsDisplayGroupInvalidShowConditionErrorWhenUnableToParseShowCondition() throws InvalidShowConditionException {
-
-            displayGroup.setShowCondition("someShowCondition");
-            displayGroup.setType(DisplayGroupType.TAB);
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenThrow(new InvalidShowConditionException("someShowCondition"));
-
-            ValidationResult result = testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
-
-            assertThat(result.isValid(), is(false));
-            assertThat(result.getValidationErrors(), hasSize(1));
-            assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabShowCondition.class));
-        }
-
-        @Test
-        @DisplayName("should fail when tab show condition references invalid field from same tab")
-        public void returnsDisplayGroupInvalidShowConditionFieldWhenShowConditionReferencesInvalidFieldFromSameTab() throws InvalidShowConditionException {
-
-            displayGroup.setShowCondition("someShowCondition");
-            displayGroup.setType(DisplayGroupType.TAB);
-
-            DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
-            CaseFieldEntity caseField = new CaseFieldEntity();
-            caseField.setReference("otherField");
-            displayGroupCaseField.setCaseField(caseField);
-            displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
-
-            ShowCondition sc = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenReturn(sc);
-
-            ValidationResult result = testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
-
-            assertThat(result.isValid(), is(false));
-            assertThat(result.getValidationErrors(), hasSize(1));
-            assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabShowCondition.class));
-        }
-
-        @Test
-        @DisplayName("should fail when tab show condition references invalid field from other tab")
-        public void returnsDisplayGroupInvalidShowConditionFieldWhenShowConditionReferencesInvalidFieldFromOtherTab() throws InvalidShowConditionException {
-
-            displayGroup.setShowCondition("someShowCondition");
-            displayGroup.setType(DisplayGroupType.TAB);
-            CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
-            caseTypeEntity.setReference("SimpleType");
-            displayGroup.setCaseType(caseTypeEntity);
-
-
-            DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
-            CaseFieldEntity caseField = new CaseFieldEntity();
-            caseField.setReference("otherField");
-            displayGroupCaseField.setCaseField(caseField);
-            DisplayGroupEntity otherTabDisplayGroup = new DisplayGroupEntity();
-            otherTabDisplayGroup.setType(DisplayGroupType.TAB);
-            otherTabDisplayGroup.addDisplayGroupCaseField(displayGroupCaseField);
-            otherTabDisplayGroup.setCaseType(caseTypeEntity);
-            allTabDisplayGroups.add(otherTabDisplayGroup);
-
-            ShowCondition sc = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
-            when(mockShowConditionParser.parseShowCondition("someShowCondition"))
-                .thenReturn(sc);
-
-            ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
-
-            assertThat(result.isValid(), is(false));
-            assertThat(result.getValidationErrors(), hasSize(1));
-            assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabShowCondition.class));
-        }
+        verify(mockShowConditionParser, never()).parseShowCondition(anyString());
     }
 
+    @Test
+//    @DisplayName("should not execute when tab show type is not tab")
+    public void TabFieldShowCondition_shouldNotExecuteWhenShowTypeIsNotTab() throws InvalidShowConditionException {
+
+        DisplayGroupCaseFieldEntity displayGroupCaseFieldEntity = new DisplayGroupCaseFieldEntity();
+        displayGroupCaseFieldEntity.setShowCondition("someShowCondition");
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseFieldEntity);
+        displayGroup.setType(DisplayGroupType.PAGE);
+
+        testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
+
+        verify(mockShowConditionParser, never()).parseShowCondition(anyString());
+    }
+
+    @Test
+//    @DisplayName("should return no errors when tab field referenced field in other tab")
+    public void TabFieldShowCondition_returnsNoValidationErrorsOnSuccessWhenReferencedFieldInOtherTab() throws InvalidShowConditionException {
+
+        displayGroup.setType(DisplayGroupType.TAB);
+        CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
+        caseTypeEntity.setReference("SimpleType");
+        displayGroup.setCaseType(caseTypeEntity);
+        DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
+        displayGroupCaseField.setShowCondition("someShowCondition");
+        CaseFieldEntity caseField = new CaseFieldEntity();
+        caseField.setReference("thisField");
+        displayGroupCaseField.setCaseField(caseField);
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
+        allTabDisplayGroups.add(displayGroup);
+
+        DisplayGroupCaseFieldEntity displayGroupCaseFieldOther = new DisplayGroupCaseFieldEntity();
+        CaseFieldEntity caseFieldOther = new CaseFieldEntity();
+        caseFieldOther.setReference("otherField");
+        displayGroupCaseFieldOther.setCaseField(caseFieldOther);
+        DisplayGroupEntity otherTabDisplayGroup = new DisplayGroupEntity();
+        otherTabDisplayGroup.setType(DisplayGroupType.TAB);
+        otherTabDisplayGroup.addDisplayGroupCaseField(displayGroupCaseFieldOther);
+        otherTabDisplayGroup.setCaseType(caseTypeEntity);
+        allTabDisplayGroups.add(otherTabDisplayGroup);
+
+        ShowCondition validParsedShowCondition = new ShowCondition.Builder().showConditionExpression("parsedSC").field("otherField").build();
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenReturn(validParsedShowCondition);
+
+        ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
+
+        assertThat(result.isValid(), is(true));
+    }
+
+    @Test
+//    @DisplayName("should return no errors when tab field referenced field in this tab")
+    public void TabFieldShowCondition_returnsNoValidationErrorsOnSuccessWhenReferencedFieldInThisTab() throws InvalidShowConditionException {
+
+        displayGroup.setType(DisplayGroupType.TAB);
+        CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
+        caseTypeEntity.setReference("SimpleType");
+        displayGroup.setCaseType(caseTypeEntity);
+
+        DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
+        CaseFieldEntity caseField = new CaseFieldEntity();
+        caseField.setReference("field");
+        displayGroupCaseField.setCaseField(caseField);
+        displayGroupCaseField.setShowCondition("someShowCondition");
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
+        allTabDisplayGroups.add(displayGroup);
+
+        ShowCondition validParsedShowCondition = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenReturn(validParsedShowCondition);
+
+        ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
+
+        assertThat(result.isValid(), is(true));
+    }
+
+    @Test
+//    @DisplayName("should fail when unable to parse show condition for tab field")
+    public void TabFieldShowCondition_returnsDisplayGroupInvalidShowConditionErrorWhenUnableToParseShowCondition() throws InvalidShowConditionException {
+
+        displayGroup.setType(DisplayGroupType.TAB);
+        DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
+        displayGroupCaseField.setShowCondition("someShowCondition");
+        CaseFieldEntity caseField = new CaseFieldEntity();
+        caseField.setReference("field");
+        displayGroupCaseField.setCaseField(caseField);
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
+
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenThrow(new InvalidShowConditionException("someShowCondition"));
+
+        ValidationResult result = testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
+
+        assertThat(result.isValid(), is(false));
+        assertThat(result.getValidationErrors(), hasSize(1));
+        assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabFieldShowCondition.class));
+    }
+
+    @Test
+//    @DisplayName("should fail when tab field show condition references invalid field from same tab")
+    public void TabFieldShowCondition_returnsDisplayGroupInvalidShowConditionFieldWhenShowConditionReferencesInvalidFieldFromSameTab() throws InvalidShowConditionException {
+
+        displayGroup.setType(DisplayGroupType.TAB);
+        CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
+        caseTypeEntity.setReference("SimpleType");
+        displayGroup.setCaseType(caseTypeEntity);
+
+        DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
+        CaseFieldEntity caseField = new CaseFieldEntity();
+        caseField.setReference("otherField");
+        displayGroupCaseField.setCaseField(caseField);
+        displayGroupCaseField.setShowCondition("someShowCondition");
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
+        allTabDisplayGroups.add(displayGroup);
+
+        ShowCondition sc = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenReturn(sc);
+
+        ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
+
+        assertThat(result.isValid(), is(false));
+        assertThat(result.getValidationErrors(), hasSize(1));
+        assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabFieldShowCondition.class));
+    }
+
+
+    @Test
+//    @DisplayName("should fail when tab field show condition references invalid field from other tab")
+    public void TabFieldShowCondition_returnsDisplayGroupInvalidShowConditionFieldWhenShowConditionReferencesInvalidFieldFromOtherTab() throws InvalidShowConditionException {
+
+        displayGroup.setType(DisplayGroupType.TAB);
+        CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
+        caseTypeEntity.setReference("SimpleType");
+        displayGroup.setCaseType(caseTypeEntity);
+        DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
+        displayGroupCaseField.setShowCondition("someShowCondition");
+        CaseFieldEntity caseField = new CaseFieldEntity();
+        caseField.setReference("thisField");
+        displayGroupCaseField.setCaseField(caseField);
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
+
+        DisplayGroupCaseFieldEntity displayGroupCaseFieldOther = new DisplayGroupCaseFieldEntity();
+        CaseFieldEntity caseFieldOther = new CaseFieldEntity();
+        caseFieldOther.setReference("otherField");
+        displayGroupCaseFieldOther.setCaseField(caseFieldOther);
+        DisplayGroupEntity otherTabDisplayGroup = new DisplayGroupEntity();
+        otherTabDisplayGroup.setType(DisplayGroupType.TAB);
+        otherTabDisplayGroup.addDisplayGroupCaseField(displayGroupCaseFieldOther);
+        otherTabDisplayGroup.setCaseType(caseTypeEntity);
+        allTabDisplayGroups.add(otherTabDisplayGroup);
+
+        ShowCondition sc = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenReturn(sc);
+
+        ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
+
+        assertThat(result.isValid(), is(false));
+        assertThat(result.getValidationErrors(), hasSize(1));
+        assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabFieldShowCondition.class));
+    }
+
+//}
+//    @Nested
+//    class TabShowCondition {
+
+    @Test
+//    @DisplayName("should not execute when tab show condition is empty")
+    public void TabShowCondition_shouldNotExecuteWhenShowConditionIsEmpty() throws InvalidShowConditionException {
+
+        displayGroup.setShowCondition(null);
+        displayGroup.setType(DisplayGroupType.TAB);
+
+        testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
+
+        verify(mockShowConditionParser, never()).parseShowCondition(anyString());
+    }
+
+    @Test
+//    @DisplayName("should not execute when tab show condition is blank")
+    public void TabShowCondition_shouldNotExecuteWhenShowConditionIsBlank() throws InvalidShowConditionException {
+
+        displayGroup.setShowCondition("");
+        displayGroup.setType(DisplayGroupType.TAB);
+
+        testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
+
+        verify(mockShowConditionParser, never()).parseShowCondition(anyString());
+    }
+
+    @Test
+//    @DisplayName("should not execute when tab show type is not tab")
+    public void TabShowCondition_shouldNotExecuteWhenShowTypeIsNotTab() throws InvalidShowConditionException {
+
+        displayGroup.setShowCondition("someShowCondition");
+        displayGroup.setType(DisplayGroupType.PAGE);
+
+        testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
+
+        verify(mockShowConditionParser, never()).parseShowCondition(anyString());
+    }
+
+    @Test
+//    @DisplayName("should return no errors when tab referenced field in other tab")
+    public void TabShowCondition_returnsNoValidationErrorsOnSuccessWhenReferencedFieldInOtherTab() throws InvalidShowConditionException {
+
+        displayGroup.setShowCondition("someShowCondition");
+        displayGroup.setType(DisplayGroupType.TAB);
+        CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
+        caseTypeEntity.setReference("SimpleType");
+        displayGroup.setCaseType(caseTypeEntity);
+
+        DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
+        CaseFieldEntity caseField = new CaseFieldEntity();
+        caseField.setReference("field");
+        displayGroupCaseField.setCaseField(caseField);
+        DisplayGroupEntity otherTabDisplayGroup = new DisplayGroupEntity();
+        otherTabDisplayGroup.setType(DisplayGroupType.TAB);
+        otherTabDisplayGroup.addDisplayGroupCaseField(displayGroupCaseField);
+        otherTabDisplayGroup.setCaseType(caseTypeEntity);
+        allTabDisplayGroups.add(otherTabDisplayGroup);
+
+        ShowCondition validParsedShowCondition = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenReturn(validParsedShowCondition);
+
+        ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
+
+        assertThat(result.isValid(), is(true));
+    }
+
+    @Test
+//    @DisplayName("should return no errors when tab referenced field in this tab")
+    public void TabShowCondition_returnsNoValidationErrorsOnSuccessWhenReferencedFieldInThisTab() throws InvalidShowConditionException {
+
+        displayGroup.setShowCondition("someShowCondition");
+        displayGroup.setType(DisplayGroupType.TAB);
+        CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
+        caseTypeEntity.setReference("SimpleType");
+        displayGroup.setCaseType(caseTypeEntity);
+
+        DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
+        CaseFieldEntity caseField = new CaseFieldEntity();
+        caseField.setReference("field");
+        displayGroupCaseField.setCaseField(caseField);
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
+        allTabDisplayGroups.add(displayGroup);
+
+        ShowCondition validParsedShowCondition = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenReturn(validParsedShowCondition);
+
+        ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
+
+        assertThat(result.isValid(), is(true));
+    }
+
+    @Test
+//    @DisplayName("should fail when unable to parse show condition for tab")
+    public void TabShowCondition_returnsDisplayGroupInvalidShowConditionErrorWhenUnableToParseShowCondition() throws InvalidShowConditionException {
+
+        displayGroup.setShowCondition("someShowCondition");
+        displayGroup.setType(DisplayGroupType.TAB);
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenThrow(new InvalidShowConditionException("someShowCondition"));
+
+        ValidationResult result = testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
+
+        assertThat(result.isValid(), is(false));
+        assertThat(result.getValidationErrors(), hasSize(1));
+        assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabShowCondition.class));
+    }
+
+    @Test
+//    @DisplayName("should fail when tab show condition references invalid field from same tab")
+    public void TabShowCondition_returnsDisplayGroupInvalidShowConditionFieldWhenShowConditionReferencesInvalidFieldFromSameTab() throws InvalidShowConditionException {
+
+        displayGroup.setShowCondition("someShowCondition");
+        displayGroup.setType(DisplayGroupType.TAB);
+
+        DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
+        CaseFieldEntity caseField = new CaseFieldEntity();
+        caseField.setReference("otherField");
+        displayGroupCaseField.setCaseField(caseField);
+        displayGroup.addDisplayGroupCaseField(displayGroupCaseField);
+
+        ShowCondition sc = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenReturn(sc);
+
+        ValidationResult result = testObj.validate(displayGroup, UNUSED_DISPLAY_GROUPS);
+
+        assertThat(result.isValid(), is(false));
+        assertThat(result.getValidationErrors(), hasSize(1));
+        assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabShowCondition.class));
+    }
+
+    @Test
+//    @DisplayName("should fail when tab show condition references invalid field from other tab")
+    public void TabShowCondition_returnsDisplayGroupInvalidShowConditionFieldWhenShowConditionReferencesInvalidFieldFromOtherTab() throws InvalidShowConditionException {
+
+        displayGroup.setShowCondition("someShowCondition");
+        displayGroup.setType(DisplayGroupType.TAB);
+        CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
+        caseTypeEntity.setReference("SimpleType");
+        displayGroup.setCaseType(caseTypeEntity);
+
+
+        DisplayGroupCaseFieldEntity displayGroupCaseField = new DisplayGroupCaseFieldEntity();
+        CaseFieldEntity caseField = new CaseFieldEntity();
+        caseField.setReference("otherField");
+        displayGroupCaseField.setCaseField(caseField);
+        DisplayGroupEntity otherTabDisplayGroup = new DisplayGroupEntity();
+        otherTabDisplayGroup.setType(DisplayGroupType.TAB);
+        otherTabDisplayGroup.addDisplayGroupCaseField(displayGroupCaseField);
+        otherTabDisplayGroup.setCaseType(caseTypeEntity);
+        allTabDisplayGroups.add(otherTabDisplayGroup);
+
+        ShowCondition sc = new ShowCondition.Builder().showConditionExpression("parsedSC").field("field").build();
+        when(mockShowConditionParser.parseShowCondition("someShowCondition"))
+            .thenReturn(sc);
+
+        ValidationResult result = testObj.validate(displayGroup, allTabDisplayGroups);
+
+        assertThat(result.isValid(), is(false));
+        assertThat(result.getValidationErrors(), hasSize(1));
+        assertThat(result.getValidationErrors().get(0), instanceOf(DisplayGroupInvalidTabShowCondition.class));
+    }
+//    }
 }

--- a/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/endpoint/exception/SpreadsheetValidationErrorMessageCreatorTest.java
+++ b/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/endpoint/exception/SpreadsheetValidationErrorMessageCreatorTest.java
@@ -13,12 +13,9 @@ import uk.gov.hmcts.ccd.definition.store.domain.validation.authorization.Authori
 import uk.gov.hmcts.ccd.definition.store.domain.validation.casefield.*;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityInvalidCrudValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityInvalidUserRoleValidationError;
-import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype
-    .CaseTypeEntityMissingSecurityClassificationValidationError;
+import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityMissingSecurityClassificationValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.complexfield.*;
-import uk.gov.hmcts.ccd.definition.store.domain.validation.displaygroup.DisplayGroupColumnNumberValidator;
-import uk.gov.hmcts.ccd.definition.store.domain.validation.displaygroup.DisplayGroupInvalidShowConditionError;
-import uk.gov.hmcts.ccd.definition.store.domain.validation.displaygroup.DisplayGroupInvalidEventFieldShowCondition;
+import uk.gov.hmcts.ccd.definition.store.domain.validation.displaygroup.*;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.event.*;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.eventcasefield.*;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.genericlayout.GenericLayoutEntityValidatorImpl;
@@ -633,7 +630,7 @@ public class SpreadsheetValidationErrorMessageCreatorTest {
     }
 
     @Test
-    public void entityExistsInRegistry_DisplayGroupInvalidShowConditionField_customMessageReturned() {
+    public void entityExistsInRegistry_DisplayGroupInvalidEventShowConditionField_customMessageReturned() {
 
         DisplayGroupEntity displayGroupEntity = new DisplayGroupEntity();
         displayGroupEntity.setReference("dg");
@@ -654,7 +651,7 @@ public class SpreadsheetValidationErrorMessageCreatorTest {
     }
 
     @Test
-    public void entityNotInRegistry_DisplayGroupInvalidShowConditionField_defaultMessageReturned() {
+    public void entityNotInRegistry_DisplayGroupInvalidEventShowConditionField_defaultMessageReturned() {
 
         DisplayGroupEntity displayGroupEntity = new DisplayGroupEntity();
         displayGroupEntity.setReference("dg");
@@ -669,6 +666,100 @@ public class SpreadsheetValidationErrorMessageCreatorTest {
                 "Invalid show condition 'sc' for display group 'dg': unknown field 'field' for event 'event'",
                 classUnderTest.createErrorMessage(
                         new DisplayGroupInvalidEventFieldShowCondition("field", displayGroupEntity))
+        );
+    }
+
+    @Test
+    public void entityExistsInRegistry_DisplayGroupInvalidTabShowConditionField_customMessageReturned() {
+
+        DisplayGroupCaseFieldEntity displayGroupCaseFieldEntity = new DisplayGroupCaseFieldEntity();
+        displayGroupCaseFieldEntity.setCaseField(caseFieldEntity("dg", SecurityClassification.PUBLIC));
+        displayGroupCaseFieldEntity.setShowCondition("sc");
+        DefinitionDataItem definitionDataItem = mock(DefinitionDataItem.class);
+        when(definitionDataItem.getSheetName()).thenReturn(SheetName.CASE_TYPE_TAB.toString());
+        when(definitionDataItem.getString(eq(ColumnName.FIELD_SHOW_CONDITION))).thenReturn("sc");
+        when(entityToDefinitionDataItemRegistry.getForEntity(eq(displayGroupCaseFieldEntity))).thenReturn(Optional.of(definitionDataItem));
+
+        assertEquals(
+                "Invalid show condition 'sc' for tab field 'dg' on spreadsheet tab 'CaseTypeTab': unknown field 'field'",
+                classUnderTest.createErrorMessage(
+                        new DisplayGroupInvalidTabFieldShowCondition("field", displayGroupCaseFieldEntity))
+        );
+    }
+
+    @Test
+    public void entityNotInRegistry_DisplayGroupInvalidTabShowConditionField_defaultMessageReturned() {
+
+        DisplayGroupCaseFieldEntity displayGroupCaseFieldEntity = new DisplayGroupCaseFieldEntity();
+        displayGroupCaseFieldEntity.setCaseField(caseFieldEntity("dg", SecurityClassification.PUBLIC));
+        displayGroupCaseFieldEntity.setShowCondition("sc");
+        DefinitionDataItem definitionDataItem = mock(DefinitionDataItem.class);
+        when(definitionDataItem.getSheetName()).thenReturn(SheetName.CASE_TYPE_TAB.toString());
+
+        assertEquals(
+                "Invalid show condition 'sc' for tab field 'dg': unknown field 'field'",
+                classUnderTest.createErrorMessage(
+                        new DisplayGroupInvalidTabFieldShowCondition("field", displayGroupCaseFieldEntity))
+        );
+    }
+
+    @Test
+    public void entityNotInRegistry_DisplayGroupInvalidTabShowConditionField_defaultMessageWhenNoShowCondition() {
+
+        DisplayGroupCaseFieldEntity displayGroupCaseFieldEntity = new DisplayGroupCaseFieldEntity();
+        displayGroupCaseFieldEntity.setCaseField(caseFieldEntity("dg", SecurityClassification.PUBLIC));
+
+        assertEquals(
+                "Invalid show condition 'null' for tab field 'dg': unknown field 'field'",
+                classUnderTest.createErrorMessage(
+                        new DisplayGroupInvalidTabFieldShowCondition("field", displayGroupCaseFieldEntity))
+        );
+    }
+
+    @Test
+    public void entityExistsInRegistry_DisplayGroupInvalidTabShowCondition_customMessageReturned() {
+
+        DisplayGroupEntity displayGroupEntity = new DisplayGroupEntity();
+        displayGroupEntity.setShowCondition("sc");
+        displayGroupEntity.setReference("dg");
+        DefinitionDataItem definitionDataItem = mock(DefinitionDataItem.class);
+        when(definitionDataItem.getSheetName()).thenReturn(SheetName.CASE_TYPE_TAB.toString());
+        when(definitionDataItem.getString(eq(ColumnName.TAB_SHOW_CONDITION))).thenReturn("sc");
+        when(entityToDefinitionDataItemRegistry.getForEntity(eq(displayGroupEntity))).thenReturn(Optional.of(definitionDataItem));
+
+        assertEquals(
+                "Invalid show condition 'sc' for tab 'dg' on spreadsheet tab 'CaseTypeTab': unknown field 'field'",
+                classUnderTest.createErrorMessage(
+                        new DisplayGroupInvalidTabShowCondition("field", displayGroupEntity))
+        );
+    }
+
+    @Test
+    public void entityNotInRegistry_DisplayGroupInvalidTabShowCondition_defaultMessageReturned() {
+
+        DisplayGroupEntity displayGroupEntity = new DisplayGroupEntity();
+        displayGroupEntity.setShowCondition("sc");
+        displayGroupEntity.setReference("dg");
+        DefinitionDataItem definitionDataItem = mock(DefinitionDataItem.class);
+        when(definitionDataItem.getSheetName()).thenReturn(SheetName.CASE_TYPE_TAB.toString());
+
+        assertEquals(
+                "Invalid show condition 'sc' for tab 'dg': unknown field 'field'",
+                classUnderTest.createErrorMessage(
+                        new DisplayGroupInvalidTabShowCondition("field", displayGroupEntity))
+        );
+    }
+
+    @Test
+    public void entityNotInRegistry_DisplayGroupInvalidTabShowCondition_defaultMessageWhenNoShowCondition() {
+
+        DisplayGroupEntity displayGroupEntity = new DisplayGroupEntity();
+        displayGroupEntity.setReference("dg");
+
+        assertEquals(
+                "Invalid show condition 'null' for tab 'dg': unknown field 'field'",
+                classUnderTest.createErrorMessage(
+                        new DisplayGroupInvalidTabShowCondition("field", displayGroupEntity))
         );
     }
 


### PR DESCRIPTION
NOTE the branch number refers to the first story 1591 under 1831. It encompasses the entire logic needed for 1831. It was thought the whole logic would be split across 2 PRs but was easier to keep it under one.

Please remove this line and everything above and fill the following sections:

JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RDM-1831
https://tools.hmcts.net/jira/browse/RDM-1591
https://tools.hmcts.net/jira/browse/RDM-1964

Change description
Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No