### PR TITLE
RDM-1944: Enable Case Admin Web application access to Definition Store API

### DIFF
--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -23,7 +23,7 @@ idam.s2s-auth.url=${IDAM_S2S_URL:http://localhost:4502}
 idam.s2s-auth.microservice=ccd_definition
 idam.s2s-auth.totp_secret=${DEFINITION_STORE_IDAM_KEY:}
 
-casedefinitionstore.authorised.services=${DEFINITION_STORE_S2S_AUTHORISED_SERVICES:ccd_data,ccd_gw}
+casedefinitionstore.authorised.services=${DEFINITION_STORE_S2S_AUTHORISED_SERVICES:ccd_data,ccd_gw,ccd_admin}
 
 ccd.user-profile.host=${USER_PROFILE_HOST:http://localhost:4453}
 


### PR DESCRIPTION
Register `ccd_admin` as an authorised service for accessing Definition Store.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-1944

### Change description ###
Add `ccd_admin` to the list of authorised services allowed to access Definition Store.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
