### PR TITLE
Add explicit declaration of environment variable for authorised services

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -68,6 +68,9 @@ module "case-definition-store-api" {
     IDAM_USER_URL = "${var.idam_api_url}"
     IDAM_S2S_URL = "${local.s2s_url}"
     DEFINITION_STORE_IDAM_KEY = "${data.vault_generic_secret.definition_store_item_key.data["value"]}"
+
+    DEFINITION_STORE_S2S_AUTHORISED_SERVICES = "${var.authorised-services}"
+
     USER_PROFILE_HOST = "http://ccd-user-profile-api-${local.env_ase_url}"
   }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -68,3 +68,11 @@ variable "use_uk_db" {
 variable "idam_api_url" {
   default = "http://betaDevBccidamAppLB.reform.hmcts.net"
 }
+
+////////////////////////////////
+// S2S
+////////////////////////////////
+
+variable "authorised-services" {
+  default = "ccd_data,ccd_gw,ccd_admin"
+}


### PR DESCRIPTION
Declare `DEFINITION_STORE_S2S_AUTHORISED_SERVICES` environment variable explicitly, as this is required on the Azure platform (which does not use the default values defined in `application.properties`).

### JIRA link (if applicable) ###
None.

### Change description ###
Fixes a problem in the CNP `Demo` environment, where Case Definition Store was refusing access by Case Admin Web application because no authorised services were defined (due to the missing environment variable).

This change has already been tested manually by adding the missing environment variable via the Azure Portal and confirming that Case Admin Web is now able to access Case Definition Store.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
