### PR TITLE
RDM-2404: Remove "deprecated" marking for /data/case-type/{id} endpoint

### DIFF
--- a/rest-api/src/main/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionController.java
+++ b/rest-api/src/main/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionController.java
@@ -31,16 +31,12 @@ public class CaseDefinitionController {
 
     private static final Logger LOG = LoggerFactory.getLogger(CaseDefinitionController.class);
 
-    /**
-     * @deprecated Use {@link uk.gov.hmcts.ccd.definition.endpoint.CaseDefinitionController#dataCaseworkerIdAndJurisdictionIdCaseTypeGet(String, String, String)} instead.
-     */
     @RequestMapping(value = "/data/case-type/{id}", method = RequestMethod.GET, produces = {"application/json"})
     @ApiOperation(value = "Fetch a Case Type Schema", notes = "Returns the schema of a single case type.\n", response = CaseType.class)
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "A Case Type Schema"),
         @ApiResponse(code = 200, message = "Unexpected error")
     })
-    @Deprecated
     public CaseType dataCaseTypeIdGet(
         @ApiParam(value = "Case Type ID", required = true) @PathVariable("id") String id) {
         return caseTypeService.findByCaseTypeId(id).orElseThrow(() -> new NotFoundException(id));


### PR DESCRIPTION
Endpoint now required by Case Admin Web application, thus removing the "deprecated" marking.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-2404

### Change description ###
Removal of the "deprecated" marking against the `dataCaseTypeIdGet()` method (`GET /data/case-type/{id}` endpoint) in `CaseDefinitionController`. This change has been approved by @vlaurin.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
