### PR TITLE
Bintray: add mavenCentral to combat jcenter timeouts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ allprojects {
 
     repositories {
         mavenLocal()
+        mavenCentral()
         jcenter()
         maven {
             url  "https://dl.bintray.com/hmcts/hmcts-maven"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2619



I believe the logic is that when one timesout we'll try the other. So at
least there is a fallback to one that should work




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```