### PR TITLE
RDM-2707_RDM_2708 - First cut of Read User roles service implementation

### DIFF
--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/UserRoleService.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/UserRoleService.java
@@ -12,4 +12,6 @@ public interface UserRoleService {
     ServiceResponse<UserRole> saveRole(UserRole userRole);
 
     List<UserRole> getRoles(List<String> roles);
+
+    List<UserRole> getRoles();
 }

--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/UserRoleServiceImpl.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/UserRoleServiceImpl.java
@@ -59,6 +59,14 @@ public class UserRoleServiceImpl implements UserRoleService {
             .collect(toList());
     }
 
+    @Override
+    public List<UserRole> getRoles() {
+        final List<UserRoleEntity> userRoles = repository.findAll();
+        return userRoles.stream()
+            .map(UserRoleModelMapper::toModel)
+            .collect(toList());
+    }
+
     private LocalDate parseDate(String date) {
         return null == date ? null : LocalDate.parse(date);
     }

--- a/domain/src/test/java/uk/gov/hmcts/ccd/definition/store/domain/service/UserRoleServiceImplTest.java
+++ b/domain/src/test/java/uk/gov/hmcts/ccd/definition/store/domain/service/UserRoleServiceImplTest.java
@@ -132,11 +132,12 @@ class UserRoleServiceImplTest {
         }
     }
 
+
     @Nested
-    @DisplayName("GetRoles Tests")
-    class GetRolesTests {
+    @DisplayName("Get All Roles Tests")
+    class GetAllRolesTests {
         @Test
-        @DisplayName("should return userRoles if defined")
+        @DisplayName("should return all userRoles")
         void getRoles() {
             String[] roleNames = {"role1", "role2", "role3"};
             UserRoleEntity entity2 = mock(UserRoleEntity.class);
@@ -145,9 +146,9 @@ class UserRoleServiceImplTest {
             givenUserRole(roleNames[2], PUBLIC);
             givenEntityWithRole(roleNames[2], PUBLIC, entity2);
 
-            doReturn(Arrays.asList(entity, entity2)).when(repository).findByRoleIn(Arrays.asList(roleNames));
+            doReturn(Arrays.asList(entity, entity2)).when(repository).findAll();
 
-            List<UserRole> userRoles = service.getRoles(Arrays.asList(roleNames));
+            List<UserRole> userRoles = service.getRoles();
 
             assertAll(
                 () -> assertThat(userRoles.get(0).getId(), is(-3)),
@@ -160,12 +161,11 @@ class UserRoleServiceImplTest {
         }
 
         @Test
-        @DisplayName("should return empty if given roles are undefined")
+        @DisplayName("should return empty if none are available")
         void getNonExistentRoles() {
-            String[] roleNames = {"role1", "role2", "role3"};
-            doReturn(Collections.EMPTY_LIST).when(repository).findByRoleIn(Arrays.asList(roleNames));
+            doReturn(Collections.EMPTY_LIST).when(repository).findAll();
 
-            List<UserRole> userRoles = service.getRoles(Arrays.asList(roleNames));
+            List<UserRole> userRoles = service.getRoles();
 
             assertThat(userRoles.size(), is(0));
         }

--- a/rest-api/src/main/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/UserRoleController.java
+++ b/rest-api/src/main/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/UserRoleController.java
@@ -67,4 +67,13 @@ class UserRoleController {
         @ApiParam(value = "Roles", required = true) @PathVariable("roles") List<String> roles) {
         return this.userRoleService.getRoles(roles);
     }
+
+    @RequestMapping(value = "/all-roles", method = RequestMethod.GET, produces = {"application/json"})
+    @ApiOperation(value = "Get All user role definitions", notes = "", response = UserRole.class, responseContainer = "List")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "User Roles Response is returned"),
+    })
+    public List<UserRole> getAllUserRoles() {
+            return this.userRoleService.getRoles();
+    }
 }

--- a/rest-api/src/test/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/UserRoleControllerTest.java
+++ b/rest-api/src/test/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/UserRoleControllerTest.java
@@ -44,6 +44,7 @@ class UserRoleControllerTest {
     private static final String URL_API_USER_ROLE = "/api/user-role";
     private static final UriTemplate URL_TEMPLATE = new UriTemplate(URL_API_USER_ROLE + "?role={role}");
     private static final String URL_API_USER_ROLES = "/api/user-roles/role1,role2";
+    private static final String URL_API_ALL_USER_ROLES = "/api/all-roles";
     private static final String ROLE_DEFINED = "@<\"*#$%^\\/";
     private static final String ROLE1 = "role1";
     private static final String ROLE2 = "role2";
@@ -157,6 +158,34 @@ class UserRoleControllerTest {
             assertAll(
                 () -> assertThat(mvcResult.getResponse().getStatus(), is(SC_OK)),
                 () -> assertThat(userRoles.size(), is(0))
+            );
+        }
+
+
+        @Test
+        void shouldGetAllRoles() throws Exception {
+            final UserRole mockUserRole = buildUserRole(ROLE1, 1);
+            final UserRole mockUserRole2 = buildUserRole(ROLE2, 2);
+            List<UserRole> roles = Arrays.asList(mockUserRole, mockUserRole2);
+            when(userRoleService.getRoles()).thenReturn(roles);
+
+            final MvcResult mvcResult = mockMvc.perform(
+                get(URL_API_ALL_USER_ROLES))
+                .andExpect(status().isOk())
+                .andReturn();
+
+            final List<UserRole> userRoles = MAPPER.readValue(mvcResult.getResponse().getContentAsString(),
+                TypeFactory.defaultInstance().constructType(new TypeReference<List<UserRole>>(){}));
+
+            assertAll(
+                () -> assertThat(mvcResult.getResponse().getStatus(), is(SC_OK)),
+                () -> assertThat(userRoles.size(), is(2)),
+                () -> assertThat(userRoles.get(0).getId(), is(1)),
+                () -> assertThat(userRoles.get(0).getRole(), is(ROLE1)),
+                () -> assertThat(userRoles.get(0).getSecurityClassification(), is(mockUserRole.getSecurityClassification())),
+                () -> assertThat(userRoles.get(1).getId(), is(2)),
+                () -> assertThat(userRoles.get(1).getRole(), is(ROLE2)),
+                () -> assertThat(userRoles.get(1).getSecurityClassification(), is(mockUserRole2.getSecurityClassification()))
             );
         }
     }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2707

As a CMCA, I want to the ability to view a list of existing user roles in ccd for a selected/assigned jurisdiction backend implementation of which is done under
https://tools.hmcts.net/jira/browse/RDM-2708

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
