### PR TITLE
RDM-2903 Make retrieval of Case Types faster in Create Case filters

### DIFF
--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/EntityToResponseDTOMapper.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/EntityToResponseDTOMapper.java
@@ -57,6 +57,14 @@ public interface EntityToResponseDTOMapper {
     )
     CaseEvent map(EventEntity eventEntity);
 
+    @Mapping(
+        expression = "java(eventLiteEntity.getPreStates().isEmpty() ? java.util.Collections.emptyList()" +
+            ": eventLiteEntity.getPreStates().stream().map(StateLiteEntity::getReference).collect(java.util.stream.Collectors.toList()))",
+        target = "preStates"
+    )
+    @Mapping(source = "eventLiteEntity.reference", target = "id")
+    CaseEventLite map(EventLiteEntity eventLiteEntity);
+
     @Mapping(source = "jurisdictionEntity.reference", target = "id")
     @Mapping(source = "jurisdictionEntity.liveTo", target = "liveUntil")
     Jurisdiction map(JurisdictionEntity jurisdictionEntity);

--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/EntityToResponseDTOMapper.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/EntityToResponseDTOMapper.java
@@ -58,7 +58,8 @@ public interface EntityToResponseDTOMapper {
     CaseEvent map(EventEntity eventEntity);
 
     @Mapping(
-        expression = "java(eventLiteEntity.getPreStates().isEmpty() ? java.util.Collections.emptyList()" +
+        expression = "java(eventLiteEntity.isCanCreate() ? java.util.Collections.emptyList() " +
+            ": eventLiteEntity.getPreStates().isEmpty() ? java.util.Arrays.asList(\"*\") " +
             ": eventLiteEntity.getPreStates().stream().map(StateLiteEntity::getReference).collect(java.util.stream.Collectors.toList()))",
         target = "preStates"
     )

--- a/domain/src/test/java/uk/gov/hmcts/ccd/definition/store/domain/service/EntityToResponseDTOMapperTest.java
+++ b/domain/src/test/java/uk/gov/hmcts/ccd/definition/store/domain/service/EntityToResponseDTOMapperTest.java
@@ -294,6 +294,115 @@ class EntityToResponseDTOMapperTest {
         }
     }
 
+
+    @Nested
+    @DisplayName("Should return a CaseEventLite which matches the CaseEventLiteEntity")
+    class MapEventLiteEntityTests {
+
+        @Test
+        void testMapEventLiteEntity() {
+
+            StateLiteEntity preState = new StateLiteEntity();
+            preState.setReference("some state");
+
+            EventLiteEntity eventLiteEntity = new EventLiteEntity();
+            eventLiteEntity.setId(1);
+            eventLiteEntity.setCanCreate(false);
+            eventLiteEntity.setName("Some name");
+            eventLiteEntity.setReference("Some reference");
+            eventLiteEntity.setDescription("Some Description");
+            eventLiteEntity.getPreStates().add(preState);
+
+            CaseEventLite caseEventLite = classUnderTest.map(eventLiteEntity);
+
+            assertEquals(eventLiteEntity.getDescription(), caseEventLite.getDescription());
+            assertEquals(eventLiteEntity.getName(), caseEventLite.getName());
+            assertEquals(eventLiteEntity.getPreStates().size(), caseEventLite.getPreStates().size());
+            assertEquals(eventLiteEntity.getReference(), caseEventLite.getId());
+
+        }
+
+        @Test
+        void testMapEmptyJurisdictionEntity() {
+
+            EventLiteEntity eventLiteEntity = new EventLiteEntity();
+            eventLiteEntity.setCanCreate(true);
+
+            CaseEventLite caseEventLite = classUnderTest.map(eventLiteEntity);
+
+            assertNull(caseEventLite.getDescription());
+            assertNull(caseEventLite.getName());
+            assertEquals(caseEventLite.getPreStates().size(), 0);
+            assertNull(caseEventLite.getId());
+
+        }
+    }
+
+    @Nested
+    @DisplayName("Should return a CaseTypeLite which matches the CaseTypeLiteEntity")
+    class MapCaseTypeLiteEntityTests {
+
+        @Test
+        void testMapCaseTypeLiteEntity() {
+
+            // Set up
+            JurisdictionEntity jurisdictionEntity = new JurisdictionEntity();
+            Jurisdiction jurisdiction = new Jurisdiction();
+            when(spyOnClassUnderTest.map(jurisdictionEntity)).thenReturn(jurisdiction);
+
+            EventLiteEntity eventEntity1 = new EventLiteEntity();
+            EventLiteEntity eventEntity2 = new EventLiteEntity();
+            EventLiteEntity eventEntity3 = new EventLiteEntity();
+            CaseEventLite caseEvent1 = new CaseEventLite();
+            CaseEventLite caseEvent2 = new CaseEventLite();
+            CaseEventLite caseEvent3 = new CaseEventLite();
+            when(spyOnClassUnderTest.map(eventEntity1)).thenReturn(caseEvent1);
+            when(spyOnClassUnderTest.map(eventEntity2)).thenReturn(caseEvent2);
+            when(spyOnClassUnderTest.map(eventEntity3)).thenReturn(caseEvent3);
+
+            StateLiteEntity stateEntity1 = new StateLiteEntity();
+            StateLiteEntity stateEntity2 = new StateLiteEntity();
+            StateLiteEntity stateEntity3 = new StateLiteEntity();
+            CaseStateLite caseState1 = new CaseStateLite();
+            CaseStateLite caseState2 = new CaseStateLite();
+            CaseStateLite caseState3 = new CaseStateLite();
+            when(spyOnClassUnderTest.map(stateEntity1)).thenReturn(caseState1);
+            when(spyOnClassUnderTest.map(stateEntity2)).thenReturn(caseState2);
+            when(spyOnClassUnderTest.map(stateEntity3)).thenReturn(caseState3);
+
+            CaseTypeLiteEntity caseTypeLiteEntity = new CaseTypeLiteEntity();
+            caseTypeLiteEntity.setName("some state name");
+            caseTypeLiteEntity.setReference("some state ref");
+            caseTypeLiteEntity.setDescription("some state description");
+            caseTypeLiteEntity.addEvent(eventEntity1).addEvent(eventEntity2).addEvent(eventEntity3);
+            caseTypeLiteEntity.addState(stateEntity1).addState(stateEntity2).addState(stateEntity3);
+            caseTypeLiteEntity.setJurisdiction(jurisdictionEntity);
+
+            CaseTypeLite caseTypeLite = classUnderTest.map(caseTypeLiteEntity);
+
+            assertEquals(caseTypeLiteEntity.getDescription(), caseTypeLite.getDescription());
+            assertEquals(caseTypeLiteEntity.getName(), caseTypeLite.getName());
+            assertEquals(caseTypeLiteEntity.getReference(), caseTypeLite.getId());
+
+            assertEquals(3, caseTypeLite.getEvents().size());
+
+            assertEquals(3, caseTypeLite.getStates().size());
+        }
+
+        @Test
+        void testMapEmptyCaseTypeLiteEntity() {
+
+            CaseTypeLiteEntity caseTypeLiteEntity = new CaseTypeLiteEntity();
+
+            CaseTypeLite caseTypeLite = classUnderTest.map(caseTypeLiteEntity);
+
+            assertNull(caseTypeLite.getDescription());
+            assertNull(caseTypeLite.getName());
+            assertNull(caseTypeLite.getId());
+
+        }
+    }
+
     @Nested
     @DisplayName("Should create a CaseEvent matching EventEntity fields, with the following exceptions/amendments:" +
         "- preStates should be empty if canCreate is true " +

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseTypeLiteEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseTypeLiteEntity.java
@@ -3,14 +3,7 @@ package uk.gov.hmcts.ccd.definition.store.repository.entity;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -55,6 +48,11 @@ public class CaseTypeLiteEntity implements Serializable, Versionable {
     @Fetch(value = FetchMode.SUBSELECT)
     @JoinColumn(name = "case_type_id")
     private final List<StateLiteEntity> states = new ArrayList<>();
+
+    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true)
+    @Fetch(value = FetchMode.SUBSELECT)
+    @JoinColumn(name = "case_type_id")
+    private final List<EventLiteEntity> events = new ArrayList<>();
 
     public Integer getId() {
         return id;
@@ -115,4 +113,12 @@ public class CaseTypeLiteEntity implements Serializable, Versionable {
         states.add(state);
         return this;
     }
-}
+
+    public List<EventLiteEntity> getEvents() {
+        return events;
+    }
+
+    public CaseTypeLiteEntity addEvent(@NotNull final EventLiteEntity event) {
+        events.add(event);
+        return this;
+    }}

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventLiteEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventLiteEntity.java
@@ -33,6 +33,9 @@ public class EventLiteEntity implements Serializable, Referencable {
     @Column(name = "description")
     private String description;
 
+    @Column(name = "can_create", nullable = false)
+    private Boolean canCreate = Boolean.FALSE;
+
     @ManyToMany(fetch = EAGER)
     @Fetch(value = SUBSELECT)
     @JoinTable(
@@ -69,6 +72,18 @@ public class EventLiteEntity implements Serializable, Referencable {
 
     public String getDescription() {
         return description;
+    }
+
+    public boolean isCanCreate() {
+        return canCreate;
+    }
+
+    public boolean getCanCreate() {
+        return canCreate;
+    }
+
+    public void setCanCreate(final boolean canCreate) {
+        this.canCreate = canCreate;
     }
 
     public void setDescription(String description) {

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventLiteEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventLiteEntity.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.ccd.definition.store.repository.entity;
+
+import org.hibernate.annotations.Fetch;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.persistence.FetchType.EAGER;
+import static javax.persistence.GenerationType.IDENTITY;
+import static org.hibernate.annotations.FetchMode.SUBSELECT;
+
+/**
+ * A "lite" version of the {@link EventEntity} class that contains selected Event fields (id, reference, name, and
+ * description) for display purposes. (Class introduced to avoid loading the whole EventEntity, which is unnecessary.)
+ */
+@Table(name = "event")
+@Entity
+public class EventLiteEntity implements Serializable, Referencable {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @Column(name = "reference", nullable = false)
+    private String reference;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @ManyToMany(fetch = EAGER)
+    @Fetch(value = SUBSELECT)
+    @JoinTable(
+        name = "event_pre_state",
+        joinColumns = @JoinColumn(name="event_id", referencedColumnName="id"),
+        inverseJoinColumns = @JoinColumn(name="state_id", referencedColumnName="id")
+    )
+    private final List<StateLiteEntity> preStates = new ArrayList<>();
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<StateLiteEntity> getPreStates() {
+        return preStates;
+    }
+}

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/model/CaseEventLite.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/model/CaseEventLite.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.ccd.definition.store.repository.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A "lite" version of the {@link CaseEvent} class that contains selected Event fields (id, name, and description) for
+ * display purposes.
+ */
+public class CaseEventLite {
+    private String id = null;
+    private String name = null;
+    private String description = null;
+
+    @JsonProperty("pre_states")
+    private List<String> preStates = new ArrayList<>();
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<String> getPreStates() {
+        return preStates;
+    }
+
+    public void setPreStates(List<String> preStates) {
+        this.preStates = preStates;
+    }
+}

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/model/CaseTypeLite.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/model/CaseTypeLite.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.definition.store.repository.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -10,7 +11,8 @@ public class CaseTypeLite {
     private String id = null;
     private String description = null;
     private String name;
-    private List<CaseStateLite> states = null;
+    private List<CaseStateLite> states = new ArrayList<>();
+    private List<CaseEventLite> events = new ArrayList<>();
 
     public String getId() {
         return id;
@@ -42,5 +44,13 @@ public class CaseTypeLite {
 
     public void setStates(List<CaseStateLite> states) {
         this.states = states;
+    }
+
+    public List<CaseEventLite> getEvents() {
+        return events;
+    }
+
+    public void setEvents(List<CaseEventLite> events) {
+        this.events = events;
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2903

Added Case Event Lite object for returning the Events of a Case Type on GET /jurisdictions query. Also added pre_states to let the FE decide if the event is a "Create Event"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```