### PR TITLE
[PREVIEW] RDM-2918: Database table definition for "definition_designer" table

### DIFF
--- a/repository/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-master.xml
@@ -42,5 +42,6 @@
     <include file="db/changelog/db.changelog-rdm-1240.4.xml"/>
     <include file="db/changelog/db.changelog-rdm-1289.xml"/>
     <include file="db/changelog/db.changelog-rdm-2835.xml"/>
+    <include file="db/changelog/db.changelog-rdm-2918.xml"/>
 
 </databaseChangeLog>

--- a/repository/src/main/resources/db/changelog/db.changelog-rdm-2918.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-rdm-2918.xml
@@ -1,0 +1,62 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <property name="now" value="now()" dbms="postgresql"/>
+
+    <changeSet id="rdm-2918" author="daniel.lam@hmcts.net">
+        <sql>
+            CREATE TYPE definitionStatus AS ENUM ('DRAFT', 'PUBLISHED');
+        </sql>
+
+        <createTable tableName="definition_designer">
+            <column name="id" type="serial">
+                <constraints nullable="false"/>
+            </column>
+            <column name="jurisdiction_id" type="integer">
+                <constraints nullable="false"/>
+            </column>
+            <column name="case_types" type="varchar(100)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="description" type="varchar(100)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="integer">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="definitionStatus">
+                <constraints nullable="false"/>
+            </column>
+            <column name="data" type="jsonb">
+                <constraints nullable="false"/>
+            </column>
+            <column name="author" type="varchar(70)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="datetime" defaultValueDate="${now}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_modified" type="datetime" defaultValueDate="${now}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deleted" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey tableName="definition_designer"
+                       columnNames="id"
+                       constraintName="pk_definition_designer"/>
+
+        <addForeignKeyConstraint baseTableName="definition_designer"
+                                 baseColumnNames="jurisdiction_id"
+                                 constraintName="fk_definition_designer_jurisdiction_id"
+                                 referencedTableName="jurisdiction"
+                                 referencedColumnNames="id"/>
+
+        <addUniqueConstraint tableName="definition_designer"
+                             columnNames="jurisdiction_id, version"
+                             constraintName="unique_definition_designer_jurisdiction_id_version"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
New database table for storing draft Case Definitions.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-2918.

### Change description ###
Liquibase changelog for creating new `definition_designer` table, for working with draft Definitions.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
