### PR TITLE
RDM-3105: Prefix Definition filenames with timestamp upon Azure Storage upload

### DIFF
--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/azurestorage/exception/FileStorageException.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/azurestorage/exception/FileStorageException.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.ccd.definition.store.excel.azurestorage.exception;
 
 public class FileStorageException extends RuntimeException {
-    public static final String FILE_ALREADY_EXISTS_ERROR = "File already exists in the Azure storage container";
 
     public FileStorageException(Exception e) {
         super(e);

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/endpoint/exception/RestResponseEntityExceptionHandler.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/endpoint/exception/RestResponseEntityExceptionHandler.java
@@ -72,14 +72,10 @@ class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler 
     }
 
     @ExceptionHandler(FileStorageException.class)
-    public void handleFileExistsException(HttpServletResponse response,
-                                          FileStorageException fileStorageException) throws IOException {
+    public void handleFileStorageException(HttpServletResponse response,
+                                           FileStorageException fileStorageException) throws IOException {
         log.error("Exception thrown: {}", fileStorageException.getMessage(), fileStorageException);
-        if (fileStorageException.getMessage().equals(FileStorageException.FILE_ALREADY_EXISTS_ERROR)) {
-            response.sendError(HttpStatus.BAD_REQUEST.value());
-        } else {
-            response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
-        }
+        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
     }
 
     private String flattenExceptionMessages(RuntimeException ex) {

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/util/DateTimeStringGenerator.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/util/DateTimeStringGenerator.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.ccd.definition.store.excel.util;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class DateTimeStringGenerator {
+
+    /**
+     * Generate a date/time string with the current time in UTC.
+     *
+     * @return The date/time, in the format <code>yyyyMMddHHmmss</code>
+     */
+    public String generateCurrentDateTime() {
+        LocalDateTime localDateTime = LocalDateTime.now(ZoneId.of("UTC"));
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+    }
+}

--- a/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/azurestorage/service/AzureBlobStorageClientTest.java
+++ b/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/azurestorage/service/AzureBlobStorageClientTest.java
@@ -6,6 +6,9 @@ import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -13,11 +16,14 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.ccd.definition.store.excel.azurestorage.exception.FileStorageException;
 import uk.gov.hmcts.ccd.definition.store.excel.domain.definition.model.DefinitionFileUploadMetadata;
+import uk.gov.hmcts.ccd.definition.store.excel.util.DateTimeStringGenerator;
 
+import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;
@@ -29,23 +35,31 @@ import static org.mockito.Mockito.when;
 @PrepareForTest({CloudBlobContainer.class, CloudBlockBlob.class})
 public class AzureBlobStorageClientTest {
 
+    private static final String DATE_TIME_PREFIX = "20181004120000";
+    private static final String FILENAME = "Definition";
     private CloudBlobContainer cloudBlobContainer;
     private CloudBlockBlob cloudBlockBlob;
 
+    @Mock
+    private DateTimeStringGenerator dateTimeStringGenerator;
+
+    @InjectMocks
     private AzureBlobStorageClient clientUnderTest;
 
     @Before
     public void setUp() {
         cloudBlobContainer = PowerMockito.mock(CloudBlobContainer.class);
         cloudBlockBlob = PowerMockito.mock(CloudBlockBlob.class);
-        clientUnderTest = new AzureBlobStorageClient(cloudBlobContainer);
+        MockitoAnnotations.initMocks(this);
+        clientUnderTest = new AzureBlobStorageClient(cloudBlobContainer, dateTimeStringGenerator);
     }
 
     @Test
     public void testFileUpload() throws Exception {
-        when(cloudBlobContainer.getBlockBlobReference(any(String.class))).thenReturn(cloudBlockBlob);
-        clientUnderTest.uploadFile(new MockMultipartFile("x", "x".getBytes("UTF-8")),
-            mock(DefinitionFileUploadMetadata.class));
+        when(cloudBlobContainer.getBlockBlobReference(DATE_TIME_PREFIX + "_" + FILENAME)).thenReturn(cloudBlockBlob);
+        when(dateTimeStringGenerator.generateCurrentDateTime()).thenReturn(DATE_TIME_PREFIX);
+        clientUnderTest.uploadFile(new MockMultipartFile("x", FILENAME, MediaType.APPLICATION_OCTET_STREAM,
+            "x".getBytes("UTF-8")), mock(DefinitionFileUploadMetadata.class));
         verify(cloudBlockBlob).setMetadata(any());
         verify(cloudBlockBlob, times(1)).upload(any(InputStream.class), anyLong());
     }
@@ -72,13 +86,6 @@ public class AzureBlobStorageClientTest {
         MultipartFile file = mock(MultipartFile.class);
         when(file.getInputStream()).thenThrow(new IOException());
         clientUnderTest.uploadFile(file, mock(DefinitionFileUploadMetadata.class));
-    }
-
-    @Test(expected = FileStorageException.class)
-    public void testFileAlreadyExists() throws Exception {
-        when(cloudBlobContainer.getBlockBlobReference(any(String.class))).thenReturn(cloudBlockBlob);
-        when(cloudBlockBlob.exists()).thenReturn(true);
-        clientUnderTest.uploadFile(mock(MultipartFile.class), mock(DefinitionFileUploadMetadata.class));
     }
 
     @Test(expected = StorageException.class)

--- a/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/azurestorage/service/AzureBlobStorageClientTest.java
+++ b/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/azurestorage/service/AzureBlobStorageClientTest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3105.

### Change description ###
Prefix filenames with the current date/time in UTC, in the format `yyyyMMddHHmmss`, to allow multiple, non-overwriting uploads of the same Definition file.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
