### PR TITLE
RDM-3193 Error while calling create-user-role endpoint

### DIFF
--- a/application/src/test/java/uk/gov/hmcts/net/ccd/definition/store/rest/MultipleControllersEndpointIT.java
+++ b/application/src/test/java/uk/gov/hmcts/net/ccd/definition/store/rest/MultipleControllersEndpointIT.java
@@ -11,7 +11,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static uk.gov.hmcts.ccd.definition.store.repository.SecurityClassification.*;
+import static uk.gov.hmcts.ccd.definition.store.repository.SecurityClassification.PRIVATE;
+import static uk.gov.hmcts.ccd.definition.store.repository.SecurityClassification.PUBLIC;
+import static uk.gov.hmcts.ccd.definition.store.repository.SecurityClassification.RESTRICTED;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -216,6 +218,27 @@ public class MultipleControllersEndpointIT extends BaseTest {
             () -> assertThat(userRoles.get(0).getSecurityClassification(), is(PUBLIC)),
             () -> assertThat(userRoles.get(1).getSecurityClassification(), is(PRIVATE)),
             () -> assertThat(userRoles.get(2).getSecurityClassification(), is(RESTRICTED))
+        );
+    }
+
+    @Test
+    public void shouldSaveUserRole() throws Exception {
+        final String URL = ROLES_URL.substring(0, ROLES_URL.length() - 4);
+        MvcResult result = mockMvc
+            .perform(MockMvcRequestBuilders
+                .put(URL)
+                .contentType("application/json")
+                .accept("application/json")
+                .content("{\"role\":\"to-delete-1\",\"security_classification\":\"PUBLIC\"}"))
+            .andExpect(MockMvcResultMatchers.status().isCreated())
+            .andReturn();
+        final UserRole userRole = mapper.readValue(result.getResponse().getContentAsString(),
+            TypeFactory.defaultInstance().constructType(new TypeReference<UserRole>() {
+            }));
+        assertAll(
+            () -> assertThat(userRole.getSecurityClassification(), is(PUBLIC)),
+            () -> assertThat(userRole.getRole(), is("to-delete-1")),
+            () -> assertThat(userRole.getId(), is(notNullValue()))
         );
     }
 

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/model/UserRoleModelMapper.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/model/UserRoleModelMapper.java
@@ -13,6 +13,7 @@ public class UserRoleModelMapper {
     public static UserRoleEntity toEntity(@NotNull UserRole model) {
         final UserRoleEntity entity = new UserRoleEntity();
         entity.setReference(model.getRole());
+        entity.setName(model.getRole());
         entity.setSecurityClassification(model.getSecurityClassification());
         return entity;
     }


### PR DESCRIPTION
Due to latest changes the user-role creation API has been broken due to null constraint in newly introduced `role` table. 
Now we use the role name submitted via API in both role reference and role name.
Also added a test for user-role creation...
https://tools.hmcts.net/jira/browse/RDM-3193

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```