### PR TITLE
changed import listener to create and close a new ES client on each i…

### DIFF
--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -2,6 +2,7 @@ server.port=4451
 
 logging.level.org.springframework.web=INFO
 logging.level.uk.gov.hmcts.ccd=INFO
+logging.level.org.elasticsearch.client=INFO
 
 spring.datasource.url=jdbc:postgresql://${DEFINITION_STORE_DB_HOST:localhost}:${DEFINITION_STORE_DB_PORT:5000}/${DEFINITION_STORE_DB_NAME:ccd_definition}?ssl=${DEFINITION_STORE_DB_USE_SSL:true}
 spring.datasource.username=${DEFINITION_STORE_DB_USERNAME:ccd}

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/AsynchronousElasticDefinitionImportListener.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/AsynchronousElasticDefinitionImportListener.java
@@ -1,11 +1,12 @@
 package uk.gov.hmcts.ccd.definition.store.elastic;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionalEventListener;
-import uk.gov.hmcts.ccd.definition.store.elastic.client.CCDElasticClient;
+import uk.gov.hmcts.ccd.definition.store.elastic.client.HighLevelCCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
 import uk.gov.hmcts.ccd.definition.store.elastic.mapping.CaseMappingGenerator;
 import uk.gov.hmcts.ccd.definition.store.event.DefinitionImportedEvent;
@@ -17,8 +18,8 @@ public class AsynchronousElasticDefinitionImportListener extends ElasticDefiniti
 
     public AsynchronousElasticDefinitionImportListener(CcdElasticSearchProperties config,
         CaseMappingGenerator mappingGenerator,
-        CCDElasticClient elasticClient) {
-        super(config, mappingGenerator, elasticClient);
+        ObjectFactory<HighLevelCCDElasticClient> clientFactory) {
+        super(config, mappingGenerator, clientFactory);
     }
 
     @Async

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/ElasticDefinitionImportListener.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/ElasticDefinitionImportListener.java
@@ -55,7 +55,9 @@ public abstract class ElasticDefinitionImportListener {
         } catch (Exception exc) {
             throw new ElasticSearchInitialisationException(exc);
         } finally {
-            elasticClient.close();
+            if (elasticClient != null) {
+                elasticClient.close();
+            }
         }
     }
 

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/SynchronousElasticDefinitionImportListener.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/SynchronousElasticDefinitionImportListener.java
@@ -1,11 +1,12 @@
 package uk.gov.hmcts.ccd.definition.store.elastic;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.ccd.definition.store.elastic.client.CCDElasticClient;
+import uk.gov.hmcts.ccd.definition.store.elastic.client.HighLevelCCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
 import uk.gov.hmcts.ccd.definition.store.elastic.mapping.CaseMappingGenerator;
 import uk.gov.hmcts.ccd.definition.store.event.DefinitionImportedEvent;
@@ -17,9 +18,9 @@ public class SynchronousElasticDefinitionImportListener extends ElasticDefinitio
 
     @Autowired
     public SynchronousElasticDefinitionImportListener(CcdElasticSearchProperties config,
-        CaseMappingGenerator mappingGenerator,
-        CCDElasticClient elasticClient) {
-        super(config, mappingGenerator, elasticClient);
+                                                      CaseMappingGenerator mappingGenerator,
+                                                      ObjectFactory<HighLevelCCDElasticClient> clientFactory) {
+        super(config, mappingGenerator, clientFactory);
     }
 
     @EventListener

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/client/CCDElasticClient.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/client/CCDElasticClient.java
@@ -9,4 +9,6 @@ public interface CCDElasticClient {
     boolean upsertMapping(String aliasName, String caseTypeMapping) throws IOException;
 
     boolean aliasExists(String alias) throws IOException;
+
+    void close();
 }

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/client/HighLevelCCDElasticClient.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/client/HighLevelCCDElasticClient.java
@@ -20,10 +20,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
 
-/**
- * NOTE: imports happens seldom. To prevent unused connections to the ES cluster hanging around, we create a new HighLevelCCDElasticClient on each import
- * and we close it once the import is completed. The HighLevelCCDElasticClient is injected every time with a new ES client which opens new connections
- */
 @Slf4j
 public class HighLevelCCDElasticClient implements CCDElasticClient {
 

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/client/HighLevelCCDElasticClient.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/client/HighLevelCCDElasticClient.java
@@ -18,10 +18,12 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
 
-@Component
+/**
+ * NOTE: imports happens seldom. To prevent unused connections to the ES cluster hanging around, we create a new HighLevelCCDElasticClient on each import
+ * and we close it once the import is completed. The HighLevelCCDElasticClient is injected every time with a new ES client which opens new connections
+ */
 @Slf4j
 public class HighLevelCCDElasticClient implements CCDElasticClient {
 
@@ -67,6 +69,16 @@ public class HighLevelCCDElasticClient implements CCDElasticClient {
         boolean exists = elasticClient.indices().existsAlias(request, RequestOptions.DEFAULT);
         log.info("alias {} exists: {}", alias, exists);
         return exists;
+    }
+
+    @Override
+    public void close() {
+        try {
+            log.info("Closing the ES REST client");
+            this.elasticClient.close();
+        } catch (IOException ioe) {
+            log.error("Problem occurred when closing the ES REST client", ioe);
+        }
     }
 
     public GetAliasesResponse getAlias(String alias) throws IOException {

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/config/CcdElasticSearchProperties.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/config/CcdElasticSearchProperties.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import java.util.List;
 import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("elasticsearch")
 public class CcdElasticSearchProperties {

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/config/ElasticSearchConfiguration.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/config/ElasticSearchConfiguration.java
@@ -1,19 +1,18 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.config;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import java.io.IOException;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import uk.gov.hmcts.ccd.definition.store.elastic.client.HighLevelCCDElasticClient;
 
 @Configuration
 @ComponentScan("uk.gov.hmcts.ccd.definition.store.elastic")
@@ -26,31 +25,21 @@ public class ElasticSearchConfiguration {
 
     private RestHighLevelClient restHighLevelClient;
 
-    @PostConstruct
-    public void init() {
-
-        if (config.isElasticSearchEnabled()) {
-            RestClientBuilder builder = RestClient.builder(new HttpHost(config.getHost(), config.getPort())).setMaxRetryTimeoutMillis(60000);
-            RestClientBuilder.RequestConfigCallback requestConfigCallback = requestConfigBuilder ->
-                requestConfigBuilder.setConnectTimeout(5000)
-                    .setSocketTimeout(60000);
-            builder.setRequestConfigCallback(requestConfigCallback);
-            restHighLevelClient = new RestHighLevelClient(builder);
-        }
+    @Bean
+    @Scope(BeanDefinition.SCOPE_PROTOTYPE)
+    public RestHighLevelClient restHighLevelClient() {
+        RestClientBuilder builder = RestClient.builder(new HttpHost(config.getHost(), config.getPort())).setMaxRetryTimeoutMillis(60000);
+        RestClientBuilder.RequestConfigCallback requestConfigCallback = requestConfigBuilder ->
+            requestConfigBuilder.setConnectTimeout(5000)
+                .setSocketTimeout(60000);
+        builder.setRequestConfigCallback(requestConfigCallback);
+        return new RestHighLevelClient(builder);
     }
 
     @Bean
-    public RestHighLevelClient restHighLevelClient() {
-        return restHighLevelClient;
-    }
-
-    @PreDestroy
-    public void cleanup() {
-        try {
-            log.info("Closing the ES REST client");
-            this.restHighLevelClient.close();
-        } catch (IOException ioe) {
-            log.error("Problem occurred when closing the ES REST client", ioe);
-        }
+    @Scope(BeanDefinition.SCOPE_PROTOTYPE)
+    public HighLevelCCDElasticClient ccdElasticClient() {
+        return new HighLevelCCDElasticClient(config, restHighLevelClient()) {
+        };
     }
 }

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/config/ElasticSearchConfiguration.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/config/ElasticSearchConfiguration.java
@@ -25,6 +25,11 @@ public class ElasticSearchConfiguration {
 
     private RestHighLevelClient restHighLevelClient;
 
+    /**
+     * NOTE: imports happens seldom. To prevent unused connections to the ES cluster hanging around, we create a new HighLevelCCDElasticClient on each import
+     * and we close it once the import is completed. The HighLevelCCDElasticClient is injected every time with a new restHighLevelClient
+     * which opens new connections
+     */
     @Bean
     @Scope(BeanDefinition.SCOPE_PROTOTYPE)
     public RestHighLevelClient restHighLevelClient() {

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/CaseMappingGenerator.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/CaseMappingGenerator.java
@@ -1,5 +1,11 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
+
 import com.google.gson.stream.JsonWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.lambda.Unchecked;
@@ -7,12 +13,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.TypeMappingGenerator;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseFieldEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseTypeEntity;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.function.Function;
-
-import static java.util.stream.Collectors.toList;
 
 @Component
 @Slf4j

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/MappingGenerator.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/MappingGenerator.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping;
 
+import java.util.Map;
+import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
@@ -9,9 +12,6 @@ import uk.gov.hmcts.ccd.definition.store.elastic.mapping.support.injection.Injec
 import uk.gov.hmcts.ccd.definition.store.elastic.mapping.support.injection.TypeMappersManager;
 import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.TypeMappingGenerator;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
-
-import java.util.Map;
-import java.util.Optional;
 
 @Slf4j
 public abstract class MappingGenerator implements JsonGenerator, Injectable {

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/support/injection/TypeMappersManager.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/support/injection/TypeMappersManager.java
@@ -1,15 +1,15 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping.support.injection;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.TypeMappingGenerator;
-
 import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.collect.Maps.newHashMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.TypeMappingGenerator;
 
 /**
  * used to inject type mappers, which can't be Autowired because of a circular dependency between them. i.e. a

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/BaseTypeMappingGenerator.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/BaseTypeMappingGenerator.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping.type;
 
-import org.springframework.stereotype.Component;
-import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
-
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
 
 @Component
 public class BaseTypeMappingGenerator extends TypeMappingGenerator {

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/CollectionTypeMappingGenerator.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/CollectionTypeMappingGenerator.java
@@ -1,16 +1,16 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping.type;
 
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.stream.Collectors.toList;
+
 import com.google.gson.stream.JsonWriter;
 import org.jooq.lambda.Unchecked;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.ComplexFieldEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldTypeEntity;
-
-import java.util.List;
-
-import static com.google.common.collect.Lists.newArrayList;
-import static java.util.stream.Collectors.toList;
 
 @Component
 public class CollectionTypeMappingGenerator extends TypeMappingGenerator {

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/ComplexTypeMappingGenerator.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/ComplexTypeMappingGenerator.java
@@ -1,16 +1,16 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping.type;
 
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.stream.Collectors.toList;
+
 import com.google.gson.stream.JsonWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.lambda.Unchecked;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.ComplexFieldEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
-
-import java.util.List;
-
-import static com.google.common.collect.Lists.newArrayList;
-import static java.util.stream.Collectors.toList;
 
 @Component
 @Slf4j

--- a/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/TypeMappingGenerator.java
+++ b/elastic-search-support/src/main/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/TypeMappingGenerator.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping.type;
 
-import uk.gov.hmcts.ccd.definition.store.elastic.exception.ElasticSearchInitialisationException;
-import uk.gov.hmcts.ccd.definition.store.elastic.mapping.MappingGenerator;
-import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import uk.gov.hmcts.ccd.definition.store.elastic.exception.ElasticSearchInitialisationException;
+import uk.gov.hmcts.ccd.definition.store.elastic.mapping.MappingGenerator;
+import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
 
 public abstract class TypeMappingGenerator extends MappingGenerator {
 

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/AsynchronousElasticDefinitionImportListenerTest.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/AsynchronousElasticDefinitionImportListenerTest.java
@@ -14,7 +14,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectFactory;
-import uk.gov.hmcts.ccd.definition.store.elastic.client.CCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.client.HighLevelCCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
 import uk.gov.hmcts.ccd.definition.store.elastic.mapping.CaseMappingGenerator;

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/AsynchronousElasticDefinitionImportListenerTest.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/AsynchronousElasticDefinitionImportListenerTest.java
@@ -7,12 +7,15 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectFactory;
 import uk.gov.hmcts.ccd.definition.store.elastic.client.CCDElasticClient;
+import uk.gov.hmcts.ccd.definition.store.elastic.client.HighLevelCCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
 import uk.gov.hmcts.ccd.definition.store.elastic.mapping.CaseMappingGenerator;
 import uk.gov.hmcts.ccd.definition.store.event.DefinitionImportedEvent;
@@ -26,7 +29,10 @@ public class AsynchronousElasticDefinitionImportListenerTest {
     private AsynchronousElasticDefinitionImportListener listener;
 
     @Mock
-    private CCDElasticClient ccdElasticClient;
+    private HighLevelCCDElasticClient ccdElasticClient;
+
+    @Mock
+    private ObjectFactory<HighLevelCCDElasticClient> clientObjectFactory;
 
     @Mock
     private CcdElasticSearchProperties config;
@@ -36,6 +42,11 @@ public class AsynchronousElasticDefinitionImportListenerTest {
 
     private CaseTypeEntity caseA = new CaseTypeBuilder().withJurisdiction("jurA").withReference("caseTypeA").build();
     private CaseTypeEntity caseB = new CaseTypeBuilder().withJurisdiction("jurB").withReference("caseTypeB").build();
+
+    @BeforeEach
+    public void setUp() {
+        when(clientObjectFactory.getObject()).thenReturn(ccdElasticClient);
+    }
 
     //the listener is tested in ElasticDefinitionImportListenerTest, this is just a simple test to please Jacoco
     @Test

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/ElasticDefinitionImportListenerTest.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/ElasticDefinitionImportListenerTest.java
@@ -17,7 +17,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectFactory;
-import uk.gov.hmcts.ccd.definition.store.elastic.client.CCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.client.HighLevelCCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
 import uk.gov.hmcts.ccd.definition.store.elastic.exception.ElasticSearchInitialisationException;

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/ElasticDefinitionImportListenerTest.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/ElasticDefinitionImportListenerTest.java
@@ -63,6 +63,16 @@ public class ElasticDefinitionImportListenerTest {
     }
 
     @Test
+    public void closesClientEvenInCaseOfErrors() {
+        when(config.getCasesIndexNameFormat()).thenThrow(new RuntimeException("test"));
+
+        assertThrows(RuntimeException.class, () -> {
+            listener.onDefinitionImported(newEvent(caseA, caseB));
+            verify(ccdElasticClient).close();
+        });
+    }
+
+    @Test
     public void createsIndexIfNotExists() throws IOException {
         when(config.getCasesIndexNameFormat()).thenReturn("%s");
         when(ccdElasticClient.aliasExists(anyString())).thenReturn(false);

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/hamcresutil/IsEqualJSON.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/hamcresutil/IsEqualJSON.java
@@ -1,5 +1,11 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.hamcresutil;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Description;
@@ -8,12 +14,6 @@ import org.hamcrest.Factory;
 import org.skyscreamer.jsonassert.JSONCompare;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.JSONCompareResult;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * A Matcher for comparing JSON. From:

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/integration/CaseMappingGenerationIT.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/integration/CaseMappingGenerationIT.java
@@ -28,7 +28,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.ccd.definition.store.elastic.ElasticDefinitionImportListener;
 import uk.gov.hmcts.ccd.definition.store.elastic.TestUtils;
-import uk.gov.hmcts.ccd.definition.store.elastic.client.CCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.client.HighLevelCCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.ElasticSearchConfiguration;

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/integration/CaseMappingGenerationIT.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/integration/CaseMappingGenerationIT.java
@@ -6,6 +6,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ccd.definition.store.elastic.hamcresutil.IsEqualJSON.equalToJSONInFile;
 import static uk.gov.hmcts.ccd.definition.store.utils.CaseFieldBuilder.newField;
 import static uk.gov.hmcts.ccd.definition.store.utils.CaseFieldBuilder.newTextField;
@@ -13,7 +14,10 @@ import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.newType;
 import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.textFieldType;
 
 import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
 import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
@@ -25,6 +29,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.ccd.definition.store.elastic.ElasticDefinitionImportListener;
 import uk.gov.hmcts.ccd.definition.store.elastic.TestUtils;
 import uk.gov.hmcts.ccd.definition.store.elastic.client.CCDElasticClient;
+import uk.gov.hmcts.ccd.definition.store.elastic.client.HighLevelCCDElasticClient;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
 import uk.gov.hmcts.ccd.definition.store.elastic.config.ElasticSearchConfiguration;
 import uk.gov.hmcts.ccd.definition.store.elastic.mapping.CaseMappingGenerator;
@@ -54,7 +59,15 @@ public class CaseMappingGenerationIT implements TestUtils {
     private CaseMappingGenerator mappingGenerator;
 
     @MockBean
-    private CCDElasticClient client;
+    private HighLevelCCDElasticClient client;
+
+    @Mock
+    private ObjectFactory<HighLevelCCDElasticClient> clientObjectFactory;
+
+    @BeforeEach
+    public void setUp() {
+        when(clientObjectFactory.getObject()).thenReturn(client);
+    }
 
     @Test
     public void testListeningToDefinitionImportedEvent() throws IOException {

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/integration/CaseMappingGenerationIT.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/integration/CaseMappingGenerationIT.java
@@ -1,5 +1,17 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.integration;
 
+import java.io.IOException;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.ccd.definition.store.elastic.hamcresutil.IsEqualJSON.equalToJSONInFile;
+import static uk.gov.hmcts.ccd.definition.store.utils.CaseFieldBuilder.newField;
+import static uk.gov.hmcts.ccd.definition.store.utils.CaseFieldBuilder.newTextField;
+import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.newType;
+import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.textFieldType;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,18 +35,6 @@ import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldTypeEntity;
 import uk.gov.hmcts.ccd.definition.store.utils.CaseFieldBuilder;
 import uk.gov.hmcts.ccd.definition.store.utils.CaseTypeBuilder;
 import uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder;
-
-import java.io.IOException;
-
-import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.ccd.definition.store.elastic.hamcresutil.IsEqualJSON.equalToJSONInFile;
-import static uk.gov.hmcts.ccd.definition.store.utils.CaseFieldBuilder.newField;
-import static uk.gov.hmcts.ccd.definition.store.utils.CaseFieldBuilder.newTextField;
-import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.newType;
-import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.textFieldType;
 
 @RunWith(SpringRunner.class)
 @BootstrapWith(SpringBootTestContextBootstrapper.class)

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/AbstractMapperTest.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/AbstractMapperTest.java
@@ -1,10 +1,5 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping;
 
-import org.mockito.Mock;
-import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
-import uk.gov.hmcts.ccd.definition.store.elastic.mapping.support.injection.TypeMappersManager;
-import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.TypeMappingGenerator;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +7,11 @@ import java.util.Map;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static org.mockito.Mockito.when;
+
+import org.mockito.Mock;
+import uk.gov.hmcts.ccd.definition.store.elastic.config.CcdElasticSearchProperties;
+import uk.gov.hmcts.ccd.definition.store.elastic.mapping.support.injection.TypeMappersManager;
+import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.TypeMappingGenerator;
 
 public abstract class AbstractMapperTest {
 

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/StubComplexTypeMappingGenerator.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/StubComplexTypeMappingGenerator.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping;
 
-import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.ComplexTypeMappingGenerator;
-import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
-
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
+
+import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.ComplexTypeMappingGenerator;
+import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
 
 public class StubComplexTypeMappingGenerator extends ComplexTypeMappingGenerator {
 

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/StubTypeMappingGenerator.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/StubTypeMappingGenerator.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping;
 
-import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.TypeMappingGenerator;
-import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
-
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
+
+import uk.gov.hmcts.ccd.definition.store.elastic.mapping.type.TypeMappingGenerator;
+import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldEntity;
 
 public class StubTypeMappingGenerator extends TypeMappingGenerator {
 

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/support/JsonGeneratorTest.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/support/JsonGeneratorTest.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping.support;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.hmcts.ccd.definition.store.elastic.hamcresutil.IsEqualJSON.equalToJSONInFile;
+
 import org.jooq.lambda.Unchecked;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.ccd.definition.store.elastic.TestUtils;
 import uk.gov.hmcts.ccd.definition.store.elastic.exception.ElasticSearchInitialisationException;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.hmcts.ccd.definition.store.elastic.hamcresutil.IsEqualJSON.equalToJSONInFile;
 
 public class JsonGeneratorTest implements TestUtils {
 

--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/CollectionTypeMappingGeneratorTest.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/mapping/type/CollectionTypeMappingGeneratorTest.java
@@ -1,5 +1,12 @@
 package uk.gov.hmcts.ccd.definition.store.elastic.mapping.type;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.ccd.definition.store.elastic.hamcresutil.IsEqualJSON.equalToJSONInFile;
+import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.labelFieldType;
+import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.newType;
+import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.textFieldType;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,13 +21,6 @@ import uk.gov.hmcts.ccd.definition.store.elastic.mapping.StubTypeMappingGenerato
 import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseFieldEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.FieldTypeEntity;
 import uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.ccd.definition.store.elastic.hamcresutil.IsEqualJSON.equalToJSONInFile;
-import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.labelFieldType;
-import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.newType;
-import static uk.gov.hmcts.ccd.definition.store.utils.FieldTypeBuilder.textFieldType;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)


### PR DESCRIPTION
- Organise imports.
- changed import listener to create and close a new ES client on each import to save resources and preventing idle connections to ES hanging around

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
