### PR TITLE
[PREVIEW] Fix slow pipeline

### DIFF
--- a/aat/build.gradle
+++ b/aat/build.gradle
@@ -47,3 +47,11 @@ task functional(type: Test) {
     include "uk/gov/hmcts/ccd/definitionstore/tests/functional/**"
     useJUnitPlatform()
 }
+
+bootRepackage {
+    enabled = false
+}
+
+jar {
+    enabled = false
+}

--- a/app-insights/build.gradle
+++ b/app-insights/build.gradle
@@ -1,3 +1,7 @@
 dependencies {
     // compile "org.springframework:spring-context:5.0.7.RELEASE"
 }
+
+bootRepackage {
+    enabled = false
+}

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -8,6 +8,10 @@ jar {
     }
 }
 
+bootRepackage {
+    enabled = false
+}
+
 dependencies {
     compile project(':app-insights')
     compile project(':rest-api')

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 // Create JAR with test fixtures
 task testJar(type: Jar, dependsOn: testClasses) {
-    baseName = 'test-${project.archivesBaseName}'
+    baseName = 'test-' + project.archivesBaseName
     classifier = 'tests'
     from sourceSets.test.output
 }
@@ -19,6 +19,10 @@ configurations {
 
 jar {
     baseName = 'definition-store-domain'
+}
+
+bootRepackage {
+    enabled = false
 }
 
 ext {

--- a/elastic-search-support/build.gradle
+++ b/elastic-search-support/build.gradle
@@ -2,7 +2,9 @@ jar {
     baseName = 'definition-store-elastic-search-support'
 }
 
-
+bootRepackage {
+    enabled = false
+}
 
 dependencies {
 

--- a/excel-importer/build.gradle
+++ b/excel-importer/build.gradle
@@ -22,3 +22,7 @@ dependencies {
     testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0-beta.5'
     testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.0-beta.5'
 }
+
+bootRepackage {
+    enabled = false
+}

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -29,3 +29,11 @@ sourceSets {
         }
     }
 }
+
+bootRepackage {
+    enabled = false
+}
+
+jar {
+    enabled = false
+}

--- a/repository/build.gradle
+++ b/repository/build.gradle
@@ -2,6 +2,10 @@ jar {
     baseName = 'definition-store-repository'
 }
 
+bootRepackage {
+    enabled = false
+}
+
 ext {
     limits = [  // A lot of the model objects are not covered
         'class' : 57

--- a/rest-api/build.gradle
+++ b/rest-api/build.gradle
@@ -19,3 +19,7 @@ dependencies {
     testCompile "org.springframework.boot:spring-boot-test"
     testCompile "org.assertj:assertj-core"
 }
+
+bootRepackage {
+    enabled = false
+}


### PR DESCRIPTION
This fixes the slow stashing and unstashing in the pipeline with this application,
it also saves lots of disk space on my machine for extra bonus points.

Prior to this change this is the size of all the jars built by this application:
```
$ find . -type f -name *.jar  -exec du -h {} \;
 96M	./repository/build/libs/definition-store-repository-1.2.0-SNAPSHOT.jar
1.4G	./integration-tests/build/libs/integration-tests-1.2.0-SNAPSHOT.jar
624M	./excel-importer/build/libs/definition-store-excel-importer-1.2.0-SNAPSHOT.jar
 56K	./gradle/wrapper/gradle-wrapper.jar
 80M	./aat/build/libs/aat-1.2.0-SNAPSHOT.jar
244K	./aat/build/tmp/expandedArchives/org.jacoco.agent-0.8.0.jar_0a1ac833cae91eb2e2152073ffb36feb/jacocoagent.jar
 62M	./app-insights/build/libs/app-insights-1.2.0-SNAPSHOT.jar
176M	./application/build/libs/case-definition-store-api-1.2.0-SNAPSHOT.jar
112M	./build/libs/case-definition-store-api.jar
252K	./domain/build/libs/test-${project.archivesBaseName}-1.2.0-SNAPSHOT-tests.jar
153M	./domain/build/libs/definition-store-domain-1.2.0-SNAPSHOT.jar
307M	./elastic-search-support/build/libs/definition-store-elastic-search-support-1.2.0-SNAPSHOT.jar
681M	./rest-api/build/libs/definition-store-rest-api-1.2.0-SNAPSHOT.jar
```
= 3.6 GB

The pipeline currently stashes all jars in build/libs folders, the pipeline may be able to change back to just `build/libs/*.jar` instead of `**/build/libs/*.jar`but that would need some testing as fees and pay made that change a long time ago for their apps

Some example stash times from previous runs:
5min14s
6m25s
6m15
6m

Unstash times:
3m7
3m12
4m
2m57

This change should save an average of 9 minutes per run.

Size after this change:
```
$ find . -type f -name *.jar  -exec du -h {} \;
148K	./repository/build/libs/definition-store-repository-1.2.0-SNAPSHOT.jar
140K	./excel-importer/build/libs/definition-store-excel-importer-1.2.0-SNAPSHOT.jar
 56K	./gradle/wrapper/gradle-wrapper.jar
4.0K	./app-insights/build/libs/app-insights-1.2.0-SNAPSHOT.jar
 16K	./application/build/libs/case-definition-store-api-1.2.0-SNAPSHOT.jar
108M	./build/libs/case-definition-store-api.jar
252K	./domain/build/libs/test-domain-1.2.0-SNAPSHOT-tests.jar
184K	./domain/build/libs/definition-store-domain-1.2.0-SNAPSHOT.jar
 32K	./elastic-search-support/build/libs/definition-store-elastic-search-support-1.2.0-SNAPSHOT.jar
 20K	./rest-api/build/libs/definition-store-rest-api-1.2.0-SNAPSHOT.jar
```

= 109MB

96% decrease in size needed to transfer by jenkins!

Jars have been disabled in projects that nothing depend on them, and boot repackaging has been disabled everywhere except the root project which packages the jar for the pipeline