### PR TITLE
Temporarily disable vault reading

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -31,7 +31,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 }
 
 withNightlyPipeline(type, product, component) {
-    loadVaultSecrets(secrets)
+    //loadVaultSecrets(secrets)
     enableDbMigration()
     enableSlackNotifications('#ccd-nightly-builds')
 }


### PR DESCRIPTION
The upstream code hasn't quite sorted out vault access on nightly build
runs, so disable temporarily.




https://tools.hmcts.net/jira/browse/RDM-3295






**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```