### PR TITLE
Rdm 2984 Same case type ID can be used across multiple jurisdictions

### DIFF
--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/casetype/CaseTypeService.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/casetype/CaseTypeService.java
@@ -12,6 +12,8 @@ public interface CaseTypeService {
 
     void createAll(JurisdictionEntity jurisdiction, Collection<CaseTypeEntity> caseTypes);
 
+    List<CaseType> findAll();
+
     List<CaseType> findByJurisdictionId(String jurisdictionId);
 
     Optional<CaseType> findByCaseTypeId(String id);

--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/validation/ValidationErrorMessageCreator.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/validation/ValidationErrorMessageCreator.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.ccd.definition.store.domain.validation.caserole.CaseRoleEnti
 import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityInvalidCrudValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityInvalidUserRoleValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityMissingSecurityClassificationValidationError;
+import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityNonUniqueReferenceValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.complexfield.ComplexFieldEntityHasLessRestrictiveSecurityClassificationThanParentValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.complexfield.ComplexFieldEntityMissingSecurityClassificationValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.complexfield.ComplexFieldInvalidShowConditionError;
@@ -23,6 +24,9 @@ public interface ValidationErrorMessageCreator {
 
     String createErrorMessage(CaseTypeEntityMissingSecurityClassificationValidationError
                                   caseTypeEntityMissingSecurityClassificationValidationError);
+
+    String createErrorMessage(CaseTypeEntityNonUniqueReferenceValidationError
+                                  caseTypeEntityNonUniqueReferenceValidationError);
 
     String createErrorMessage(CaseFieldEntityHasLessRestrictiveSecurityClassificationThanParentValidationError
                                   classUnderTest);

--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/validation/casetype/CaseTypeEntityNonUniqueReferenceValidationError.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/validation/casetype/CaseTypeEntityNonUniqueReferenceValidationError.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.ccd.definition.store.domain.validation.casetype;
+
+import uk.gov.hmcts.ccd.definition.store.domain.validation.ValidationError;
+import uk.gov.hmcts.ccd.definition.store.domain.validation.ValidationErrorMessageCreator;
+import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseTypeEntity;
+import uk.gov.hmcts.ccd.definition.store.repository.model.CaseType;
+
+public class CaseTypeEntityNonUniqueReferenceValidationError extends ValidationError {
+
+    private CaseTypeEntity caseTypeEntity;
+    private CaseType existingCaseType;
+
+    public CaseTypeEntityNonUniqueReferenceValidationError(CaseTypeEntity caseTypeEntity, CaseType existingCaseType) {
+        super(
+            String.format(
+                "Case Type with reference '%s' already exists for '%s' jurisdiction. Case types must be unique across all existing jurisdictions.",
+                caseTypeEntity.getReference(),
+                existingCaseType.getJurisdiction().getName()
+            )
+        );
+        this.caseTypeEntity = caseTypeEntity;
+        this.existingCaseType = existingCaseType;
+    }
+
+    public CaseTypeEntity getCaseTypeEntity() {
+        return caseTypeEntity;
+    }
+
+    public CaseType getExistingCaseType() {
+        return existingCaseType;
+    }
+
+    @Override
+    public String createMessage(ValidationErrorMessageCreator validationErrorMessageCreator) {
+        return validationErrorMessageCreator.createErrorMessage(this);
+    }
+
+}

--- a/domain/src/test/java/uk/gov/hmcts/ccd/definition/store/domain/validation/casetype/CaseTypeEntityNonUniqueReferenceValidationErrorTest.java
+++ b/domain/src/test/java/uk/gov/hmcts/ccd/definition/store/domain/validation/casetype/CaseTypeEntityNonUniqueReferenceValidationErrorTest.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.ccd.definition.store.domain.validation.casetype;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.ccd.definition.store.domain.validation.ValidationErrorMessageCreator;
+import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseTypeEntity;
+import uk.gov.hmcts.ccd.definition.store.repository.model.CaseType;
+import uk.gov.hmcts.ccd.definition.store.repository.model.Jurisdiction;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CaseTypeEntityNonUniqueReferenceValidationErrorTest {
+
+    private static final String OVERRIDDEN_ERROR_MESSAGE = "The overridden error message";
+
+    @Mock
+    private ValidationErrorMessageCreator mockValidationErrorMessageCreator;
+
+    private CaseTypeEntityNonUniqueReferenceValidationError classUnderTest;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(mockValidationErrorMessageCreator.createErrorMessage(any(CaseTypeEntityNonUniqueReferenceValidationError.class)))
+            .thenReturn(OVERRIDDEN_ERROR_MESSAGE);
+        classUnderTest = new CaseTypeEntityNonUniqueReferenceValidationError(caseTypeEntityWithReference("Charley says Dont talk to strangers"),
+                                                                             caseTypeWithIdAndWithJurisdictionWithId("Charley says Dont talk to strangers",
+                                                                                                                     "Charley's Jurisdiction"));
+    }
+
+    @Test
+    public void testDefaultMessage() {
+        assertEquals("Case Type with name 'Charley says Dont talk to strangers' already exists for 'Charley's Jurisdiction' jurisdiction. Case types must be unique across all existing jurisdictions.",
+                     classUnderTest.getDefaultMessage());
+    }
+
+    @Test
+    public void testCreateMessage() {
+        assertEquals(OVERRIDDEN_ERROR_MESSAGE, classUnderTest.createMessage(mockValidationErrorMessageCreator));
+        verify(mockValidationErrorMessageCreator).createErrorMessage(classUnderTest);
+    }
+
+    private CaseTypeEntity caseTypeEntityWithReference(String name) {
+        CaseTypeEntity caseTypeEntity = new CaseTypeEntity();
+        caseTypeEntity.setName(name);
+        return caseTypeEntity;
+    }
+
+    private CaseType caseTypeWithIdAndWithJurisdictionWithId(String name, String jurisdictionName) {
+        CaseType caseType = new CaseType();
+        caseType.setName(name);
+        Jurisdiction jurisdictionEntity = new Jurisdiction();
+        jurisdictionEntity.setName(jurisdictionName);
+        caseType.setJurisdiction(jurisdictionEntity);
+        return caseType;
+    }
+
+}

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/endpoint/exception/SpreadsheetValidationErrorMessageCreator.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/endpoint/exception/SpreadsheetValidationErrorMessageCreator.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.ccd.definition.store.domain.validation.caserole.CaseRoleEnti
 import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityInvalidCrudValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityInvalidUserRoleValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityMissingSecurityClassificationValidationError;
+import uk.gov.hmcts.ccd.definition.store.domain.validation.casetype.CaseTypeEntityNonUniqueReferenceValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.complexfield.ComplexFieldEntityHasLessRestrictiveSecurityClassificationThanParentValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.complexfield.ComplexFieldEntityMissingSecurityClassificationValidationError;
 import uk.gov.hmcts.ccd.definition.store.domain.validation.complexfield.ComplexFieldInvalidShowConditionError;
@@ -53,6 +54,19 @@ public class SpreadsheetValidationErrorMessageCreator implements ValidationError
             caseTypeEntityMissingSecurityClassificationValidationError.getCaseTypeEntity(),
             caseTypeEntityMissingSecurityClassificationValidationError.getCaseTypeEntity().getReference(),
             caseTypeEntityMissingSecurityClassificationValidationError.getDefaultMessage());
+    }
+
+    @Override
+    public String createErrorMessage(CaseTypeEntityNonUniqueReferenceValidationError
+                                         error) {
+        return newMessageIfDefinitionExists(error,
+                                            error.getCaseTypeEntity(),
+                                            def -> String.format(
+                                                "Case Type with name '%s' already exists for '%s' jurisdiction on tab '%s'. Case types must be unique across all existing jurisdictions.",
+                                                error.getCaseTypeEntity().getReference(),
+                                                error.getExistingCaseType().getJurisdiction().getName(),
+                                                def.getSheetName())
+                                            );
     }
 
     @Override

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/CaseTypeRepository.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/CaseTypeRepository.java
@@ -21,4 +21,7 @@ public interface CaseTypeRepository extends VersionedDefinitionRepository<CaseTy
     @Query("select c from CaseTypeEntity c where c.version in (select max(cm.version) from CaseTypeEntity cm where cm.reference=c.reference) and c.jurisdiction.reference=:jurisdictionReference")
     List<CaseTypeEntity> findByJurisdictionId(@Param("jurisdictionReference") String jurisdiction);
 
+    @Query("select c from CaseTypeEntity c where c.version in (select max(cm.version) from CaseTypeEntity as cm where cm.reference = c.reference)")
+    List<CaseTypeEntity> findAll();
+
 }

--- a/repository/src/test/java/uk/gov/hmcts/ccd/definition/store/repository/CaseTypeRepositoryTest.java
+++ b/repository/src/test/java/uk/gov/hmcts/ccd/definition/store/repository/CaseTypeRepositoryTest.java
@@ -41,16 +41,23 @@ public class CaseTypeRepositoryTest {
     private static final String CASE_TYPE_REFERENCE = "id";
 
     private JurisdictionEntity testJurisdiction;
+    private JurisdictionEntity testJurisdiction2;
 
     @Before
     public void setUp() {
         this.testJurisdiction = testHelper.createJurisdiction();
+        this.testJurisdiction2 = testHelper.createJurisdiction("DIVORCE", "Divorce", "Divorce jurisdiction");
 
+        setupCaseTypeEntity("id", "Test case", testJurisdiction);
+        setupCaseTypeEntity("id2", "Test case2", testJurisdiction2);
+    }
+
+    private void setupCaseTypeEntity(String id, String name, JurisdictionEntity jurisdictionEntity) {
         final CaseTypeEntity caseType = new CaseTypeEntity();
-        caseType.setReference("id");
-        caseType.setName("Test case");
+        caseType.setReference(id);
+        caseType.setName(name);
         caseType.setVersion(1);
-        caseType.setJurisdiction(testJurisdiction);
+        caseType.setJurisdiction(jurisdictionEntity);
         caseType.setSecurityClassification(SecurityClassification.PUBLIC);
         saveCaseTypeClearAndFlushSession(caseType);
         caseType.setVersion(2);
@@ -87,6 +94,15 @@ public class CaseTypeRepositoryTest {
         List<CaseTypeEntity> caseTypeEntityOptional
             = classUnderTest.findByJurisdictionId("Non Existing Jurisdiction");
         assertTrue(caseTypeEntityOptional.isEmpty());
+    }
+
+    @Test
+    public void severalVersionsOfCaseTypesForJurisdictions_findAllCaseTypes() {
+        List<CaseTypeEntity> caseTypeEntityOptional
+            = classUnderTest.findAll();
+        assertTrue(caseTypeEntityOptional.size() == 2);
+        assertEquals(3, caseTypeEntityOptional.get(0).getVersion().intValue());
+        assertEquals(3, caseTypeEntityOptional.get(1).getVersion().intValue());
     }
 
     private void saveCaseTypeClearAndFlushSession(CaseTypeEntity caseType) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-2984


### Change description ###
Added validation where I grab all case types from db and check if the case type reference being uploaded is not already there for some other jurisdiction to the one being uploaded and if it is then create case type non unique reference ValidationError.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
