### PR TITLE
fix gradle version in Docker hub

### DIFF
--- a/hub.Dockerfile
+++ b/hub.Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk8 as builder
+FROM gradle:4.10-jdk8 as builder
 LABEL maintainer="https://github.com/hmcts/ccd-definition-store-api"
 
 COPY . /home/gradle/src


### PR DESCRIPTION

### JIRA link (if applicable) ###
N/A


### Change description ###
Fix version of Gradle to 4.10 to allow docker images to build


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
