### PR TITLE
upgraded pmd tool version to 6.11.0 (CVE-2019-7722)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ apply plugin: 'org.owasp.dependencycheck'
 apply plugin: 'pmd'
 apply from: 'liquibase.gradle'
 
+pmd {
+    toolVersion = '6.11.0'
+}
+
 mainClassName = 'uk.gov.hmcts.ccd.definition.store.CaseDataAPIApplication'
 
 // https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -153,8 +153,4 @@
         <gav regex="true">^org\.springframework:spring-.+:.*$</gav>
         <cve>CVE-2018-15756</cve>
     </suppress>
-    <suppress>
-        <notes>Temporarily suppress pmd vulnerabilities. This is non prod dependency.</notes>
-        <cve>CVE-2019-7722</cve>
-    </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -153,4 +153,8 @@
         <gav regex="true">^org\.springframework:spring-.+:.*$</gav>
         <cve>CVE-2018-15756</cve>
     </suppress>
+    <suppress>
+        <notes>Temporarily suppress pmd vulnerabilities. This is non prod dependency.</notes>
+        <cve>CVE-2019-7722</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
…rod dependency.



### Change description ###
Temporarily suppress CVE-2019-7722 pmd vulnerabilities. This is non prod dependency.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
