### PR TITLE
RDM-3940 Updated event_case_field_complex_type label to text type

### DIFF
--- a/repository/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-master.xml
@@ -56,5 +56,6 @@
     <include file="db/changelog/db.changelog-rdm-3576.xml"/>
     <include file="db/changelog/db.changelog-rdm-3327.xml"/>
     <include file="db/changelog/db.changelog-rdm-4108.xml"/>
+    <include file="db/changelog/db.changelog-rdm-3940.xml"/>
 
 </databaseChangeLog>

--- a/repository/src/main/resources/db/changelog/db.changelog-rdm-3940.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-rdm-3940.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="rdm-3940" author="rafal.kalita@hmcts.net">
+        <modifyDataType columnName="label"
+                        newDataType="text"
+                        tableName="event_case_field_complex_type"/>
+        <dropNotNullConstraint columnDataType="text"
+                               columnName="label"
+                               tableName="event_case_field_complex_type"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3940


### Change description ###
CaseEventToComplexTypes tab has a EventElementLabel we can use to override original label. This PR changes the label type in the DB to nullable Text.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
