### PR TITLE
Fix spreadsheet parser: string value of the cell

### DIFF
--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/SpreadsheetParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/SpreadsheetParser.java
@@ -46,8 +46,7 @@ public class SpreadsheetParser {
         final Map<String, DefinitionSheet> definitionSheets = new HashMap<>();
         importWarnings = new ArrayList<>();
 
-        try (InputStream is = inputStream) { // Java's try-with-resource requires a named local variable, even though unused.
-            Workbook workbook = new XSSFWorkbook(inputStream);
+        try (Workbook workbook = new XSSFWorkbook(inputStream)) {
             workbook.sheetIterator().forEachRemaining(sheet -> {
                 DefinitionSheet definitionSheet = new DefinitionSheet();
 

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/SpreadsheetParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/SpreadsheetParser.java
@@ -7,7 +7,6 @@ import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +61,8 @@ public class SpreadsheetParser {
                     boolean validRow = false;
                     while (!validRow && cellIterator.hasNext()) {
                         Cell cell = cellIterator.next();
-                        if (cell != null && cell.getCellTypeEnum() != CellType.BLANK && !((XSSFCell) cell).getRawValue().isEmpty()) {
+
+                        if (cell != null && cell.getCellTypeEnum() != CellType.BLANK && !cell.toString().isEmpty()) {
                             validRow = true;
                         }
                     }


### PR DESCRIPTION
### Change description ###

Reference: hmcts/bulk-scan-shared-infrastructure#108

Numerously tested while doing reference above and simply using `toString` which is fully implemented by the library is enough (BTW, can even get rid of `BLANK` check before. Only now thought of it). The main problem is complex string retrieval - it is not always just `_cell.getV()`.

Bottomline any import caused `NullPointerException` without any knowledge why as last cause was not exposed in server stacktrace.

Bonus overview/summary: there was a moment I missed one tiny configuration and import just looked like stuck at one place. Only figured out my mistake once provided logging for `ValidationException` in the `ControllerAdvice`

One more bonus: including tiny merge in try-with-resources so `SpreadsheetParser` doesn't have suppose "not used variable" warning. `Workbook` itself is `Closeable` so can squeeze that in and be safe everything is closed properly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
