### PR TITLE
Bump jackson-databind to v2.9.9 for CVE-2019-12086

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,9 @@ allprojects {
 
     dependencies {
         testCompile "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
+
+        // CVE-2019-12086 - force update of jackson-databind - remove when dependencies move off <2.9.9
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.9"
     }
 
     checkstyle {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -161,4 +161,12 @@
         <cve>CVE-2014-3488</cve>
         <cve>CVE-2015-2156</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+            file name: jackson-databind-2.9.8.jar
+            We've upgraded to jackson-databind 2.9.9 but the dependecy check keeps flagging it, thus mark as false positive.
+        ]]></notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.9\.8$</gav>
+        <cve>CVE-2019-12086</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-4823


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```