### PR TITLE
Log import validation errors

### DIFF
--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/casetype/CaseTypeServiceImpl.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/casetype/CaseTypeServiceImpl.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.ccd.definition.store.domain.service.DefinitionServiceImpl;
 import uk.gov.hmcts.ccd.definition.store.domain.service.EntityToResponseDTOMapper;
 import uk.gov.hmcts.ccd.definition.store.domain.service.legacyvalidation.LegacyCaseTypeValidator;
 import uk.gov.hmcts.ccd.definition.store.domain.service.metadata.MetadataFieldService;

--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/casetype/CaseTypeServiceImpl.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/casetype/CaseTypeServiceImpl.java
@@ -7,8 +7,11 @@ import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.definition.store.domain.service.DefinitionServiceImpl;
 import uk.gov.hmcts.ccd.definition.store.domain.service.EntityToResponseDTOMapper;
 import uk.gov.hmcts.ccd.definition.store.domain.service.legacyvalidation.LegacyCaseTypeValidator;
 import uk.gov.hmcts.ccd.definition.store.domain.service.metadata.MetadataFieldService;
@@ -25,6 +28,8 @@ import uk.gov.hmcts.ccd.definition.store.repository.model.CaseType;
 
 @Component
 public class CaseTypeServiceImpl implements CaseTypeService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CaseTypeServiceImpl.class);
 
     private final CaseTypeRepository repository;
     private final EntityToResponseDTOMapper dtoMapper;
@@ -72,6 +77,7 @@ public class CaseTypeServiceImpl implements CaseTypeService {
         if (validationResult.isValid()) {
             versionedRepository.saveAll(caseTypes);
         } else {
+            validationResult.getValidationErrors().forEach(vr -> LOG.info(vr.toString()));
             throw new ValidationException(validationResult);
         }
     }

--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/validation/ValidationError.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/validation/ValidationError.java
@@ -20,8 +20,6 @@ public abstract class ValidationError implements Serializable {
 
     @Override
     public String toString() {
-        return "ValidationError{" +
-            "defaultMessage='" + defaultMessage + '\'' +
-            '}';
+        return "validationError: " + defaultMessage;
     }
 }

--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/validation/ValidationError.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/validation/ValidationError.java
@@ -18,4 +18,10 @@ public abstract class ValidationError implements Serializable {
         return getDefaultMessage();
     }
 
+    @Override
+    public String toString() {
+        return "ValidationError{" +
+            "defaultMessage='" + defaultMessage + '\'' +
+            '}';
+    }
 }


### PR DESCRIPTION
On the new ITHC env we noticed that for some reason sometimes the import validation errors are not returned to the UI and are not logged. This makes it difficult to understand what the issue is because the import just fails silently. 
This quick PR adds logging of validation errors 

```
2019-05-29T14:24:13.243 INFO  [http-nio-1732-exec-9] u.g.h.c.d.s.d.service.casetype.CaseTypeServiceImpl validationError: Invalid UserRole for case type 'AAT_PRIVATE', case state 'TODO'
2019-05-29T14:24:13.243 INFO  [http-nio-1732-exec-9] u.g.h.c.d.s.d.service.casetype.CaseTypeServiceImpl validationError: Invalid UserRole for case type 'AAT_PRIVATE', case state 'TODO'
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
