### PR TITLE
RDM-4443: Remove incorrect use of @Table annotation

### DIFF
--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseRoleEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseRoleEntity.java
@@ -5,7 +5,6 @@ import java.io.Serializable;
 
 import static javax.persistence.FetchType.LAZY;
 
-@Table(name = "role")
 @Entity
 @DiscriminatorValue("CASEROLE")
 public class CaseRoleEntity extends UserRoleEntity implements Serializable {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-4443.

### Change description ###
Remove `@Table` annotation from `CaseRoleEntity` because it is a subclass of `UserRoleEntity`, which already has the annotation and is using a `SINGLE_TABLE` inheritance strategy.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
