### PR TITLE
scale up db on prod and perftest to align to aat

### DIFF
--- a/infrastructure/perftest.tfvars
+++ b/infrastructure/perftest.tfvars
@@ -5,6 +5,10 @@ asp_name = "ccd-definition-store-api-perftest"
 asp_rg = "ccd-definition-store-api-perftest"
 capacity = "2"
 
+database_sku_name = "GP_Gen5_4"
+database_sku_capacity = "4"
+database_max_pool_size = "32"
+
 elastic_search_enabled = "true"
 elastic_search_fail_on_import = "true"
 elastic_search_index_shards = 2

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -5,6 +5,10 @@ asp_name = "ccd-definition-store-api-prod"
 asp_rg = "ccd-definition-store-api-prod"
 capacity = "2"
 
+database_sku_name = "GP_Gen5_4"
+database_sku_capacity = "4"
+database_max_pool_size = "32"
+
 elastic_search_enabled = "true"
 elastic_search_fail_on_import = "true"
 elastic_search_index_shards = 2


### PR DESCRIPTION
It looks like we scaled up the def store db on AAT but not on Prod. Scaling up on Prod and PerfTest as well

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
