### PR TITLE
RDM-5242 Overrides fix when the fields in one event have similar prefix

### DIFF
--- a/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/display/DisplayGroupAdapterService.java
+++ b/domain/src/main/java/uk/gov/hmcts/ccd/definition/store/domain/service/display/DisplayGroupAdapterService.java
@@ -123,7 +123,7 @@ public class DisplayGroupAdapterService {
             .collect(Collectors.toList());
 
         return allSubTypePossibilities.stream()
-            .filter(e -> e.startsWith(displayGroupCaseFieldEntity.getCaseField().getReference()))
+            .filter(e -> e.startsWith(displayGroupCaseFieldEntity.getCaseField().getReference() + '.'))
             .filter(e -> !e.equals(displayGroupCaseFieldEntity.getCaseField().getReference()))
             .filter(e -> !complexFieldOverrideIds.contains(e))
             .collect(Collectors.toList());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-5242


### Change description ###
Adding a dot  character when filtering override possibilities to avoid a bug when names have similar beginning.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
