### PR TITLE
RDM-5730-Fix PF team changes to infra and jenkinsfile

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -53,7 +53,7 @@ withPipeline(type, product, app) {
         env.CCD_GW_SERVICE_NAME = "ccd_gw"
     }
 
-    enableDbMigration()
+    enableDbMigration('ccd')
     enableDockerBuild()
 
     overrideVaultEnvironments(vaultOverrides)

--- a/application/src/main/resources/bootstrap.yaml
+++ b/application/src/main/resources/bootstrap.yaml
@@ -6,5 +6,5 @@ spring:
         s2s.microservicekey-ccd-definition: DEFINITION_STORE_IDAM_KEY
         ccd.ccd-ELASTIC-SEARCH-URL: ELASTIC_SEARCH_HOST
         ccd.ccd-ELASTIC-SEARCH-PASSWORD: ELASTIC_SEARCH_PASSWORD
-        ccd.ccd-definition-store-api-POSTGRES-PASS: spring.datasource.password
+        ccd.definition-store-api-POSTGRES-PASS: spring.datasource.password
         ccd.storage-account-primary-connection-string: AZURE_STORAGE_CONNECTION_STRING

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -173,31 +173,31 @@ module "definition-store-db" {
 ////////////////////////////////
 
 resource "azurerm_key_vault_secret" "POSTGRES-USER" {
-  name = "${local.app_full_name}-POSTGRES-USER"
+  name = "${var.component}-POSTGRES-USER"
   value = "${module.definition-store-db.user_name}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES-PASS" {
-  name = "${local.app_full_name}-POSTGRES-PASS"
+  name = "${var.component}-POSTGRES-PASS"
   value = "${module.definition-store-db.postgresql_password}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_HOST" {
-  name = "${local.app_full_name}-POSTGRES-HOST"
+  name = "${var.component}-POSTGRES-HOST"
   value = "${module.definition-store-db.host_name}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_PORT" {
-  name = "${local.app_full_name}-POSTGRES-PORT"
+  name = "${var.component}-POSTGRES-PORT"
   value = "${module.definition-store-db.postgresql_listen_port}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
-  name = "${local.app_full_name}-POSTGRES-DATABASE"
+  name = "${var.component}-POSTGRES-DATABASE"
   value = "${module.definition-store-db.postgresql_database}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,11 +1,3 @@
-output "microserviceName" {
-  value = "${local.app_full_name}"
-}
-
-output "vaultName" {
-  value = "${local.vaultName}"
-}
-
 output "idam_url" {
   value = "${var.idam_api_url}"
 }


### PR DESCRIPTION

### Change description ###
hmcts/cnp-jenkins-library#533 changed to using the component for looking up the vault prefix, it was expected that all teams were doing this, inside of your own vault there is no need to prefix the secret with the product.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```