### PR TITLE
Address CVE warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencyCheck {
         // Disable scanning of .NET related binaries
         assemblyEnabled = false
     }
+    // Codacy introduces a vulnerable dependency.
+    // Ignore the codacy configuration since it is non runtime.
+    skipConfigurations = ['codacy']
 }
 
 //spring boot dependency override
@@ -127,7 +130,7 @@ allprojects {
     dependencies {
         testCompile "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
 
-        compile "com.fasterxml.jackson.core:jackson-databind:2.9.10"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.10.1"
     }
 
     checkstyle {
@@ -143,14 +146,6 @@ allprojects {
         resolutionStrategy {
             dependencySubstitution {
                 substitute module('org.elasticsearch:elasticsearch') with module("org.elasticsearch:elasticsearch:${elasticSearchVersion}")
-            }
-            eachDependency { DependencyResolveDetails details ->
-                if (details.requested.group in ['com.fasterxml.jackson.core', 'com.fasterxml.jackson.module', 'com.fasterxml.jackson.datatype']) {
-                    details.useVersion '2.9.10'
-                }
-                if (details.requested.name == 'jackson-databind') {
-                    details.useVersion '2.9.10'
-                }
             }
         }
     }

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -244,4 +244,20 @@
         <cve>CVE-2019-16943</cve>
         <cve>CVE-2019-17531</cve>
     </suppress>
+    <!--Liquibase bundles bootstrap and jquery in order to provide an admin UI
+        Suppressing on the basis that we do not expose this UI.-->
+    <suppress>
+        <notes><![CDATA[ file name: liquibase-core-3.6.3.jar: bootstrap.js ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/bootstrap@.*$</packageUrl>
+        <cve>CVE-2018-14040</cve>
+        <cve>CVE-2018-14041</cve>
+        <cve>CVE-2018-14042</cve>
+        <cve>CVE-2019-8331</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[ file name: liquibase-core-3.6.3.jar: jquery-1.11.0.min.js ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2015-9251</cve>
+        <cve>CVE-2019-11358</cve>
+    </suppress>
 </suppressions>

--- a/excel-importer/build.gradle
+++ b/excel-importer/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     compile "org.springframework.boot:spring-boot-starter-web"
     compile "org.apache.commons:commons-collections4:4.1"
-    compile "org.apache.poi:poi-ooxml:3.17"
+    compile "org.apache.poi:poi-ooxml:4.1.1"
 }
 
 bootJar {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-4313?filter=-1


### Change description ###
Address CVE vulnerability reports

There were genuine vulnerabilities in jackson-databind and apache.poi which I have fixed by bumping the versions.

There were also warnings concerning liquibase, which bundles vulnerable javascript as part of its administrator UI. I am suppressing these since we do not expose this UI and there is no fixed liquibase version available.

The final warning was concerning a vulnerable dependency brought in by codacy - I have excluded the codacy configuration from analysis since this is a non runtime configuration.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
