### PR TITLE
Performance improvements for /display/tab-structure/{id}

### DIFF
--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupEntity.java
@@ -11,6 +11,8 @@ import static javax.persistence.FetchType.EAGER;
 import static javax.persistence.FetchType.LAZY;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 @Table(name = "display_group")
 @Entity
@@ -53,6 +55,7 @@ public class DisplayGroupEntity implements Serializable {
     private EventEntity event;
 
     @OneToMany(mappedBy = "displayGroup", fetch = EAGER, cascade = ALL, orphanRemoval = true)
+    @Fetch(value = FetchMode.SUBSELECT)
     private final List<DisplayGroupCaseFieldEntity> displayGroupCaseFields = new ArrayList<>();
 
     @ManyToOne(cascade = ALL)

--- a/repository/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-master.xml
@@ -69,4 +69,5 @@
     <include file="db/changelog/db.changelog-rdm-4525.xml"/>
     <include file="db/changelog/db.changelog-rdm-4272.xml"/>
     <include file="db/changelog/db.changelog-rdm-5566.xml"/>
+    <include file="db/changelog/db.changelog-rdm-6336.xml"/>
 </databaseChangeLog>

--- a/repository/src/main/resources/db/changelog/db.changelog-rdm-6336.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-rdm-6336.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="rdm-6336" author="alex.mcausland@hmcts.net">
+        <createIndex indexName="display_group_case_type_id_idx"
+                     schemaName="public"
+                     tableName="display_group">
+            <column name="case_type_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
# JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-6336

### Change description ###

This fixes an N+1 query loading DisplayGroupCaseFieldEntity from DisplayGroupEntity, and improves display group loading performance by indexing case_type_id in the display_group table.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
