### PR TITLE
RDM-6596-bumped java chart version

### DIFF
--- a/charts/ccd-definition-store-api/Chart.yaml
+++ b/charts/ccd-definition-store-api/Chart.yaml
@@ -2,7 +2,7 @@ description: Helm chart for the HMCTS CCD Definition Store
 name: ccd-definition-store-api
 apiVersion: v1
 home: https://github.com/hmcts/ccd-definition-store-api
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-definition-store-api/requirements.yaml
+++ b/charts/ccd-definition-store-api/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: ~2.9.1
+    version: ~2.15.0
     repository: '@hmctspublic'


### PR DESCRIPTION

### Change description ###

java chart updated to latest version 2.15.0 to enable bulk-scanning
bulk-scanning is currently blocked because of a clash in the tpl in an old version of chart-java, this was fixed in ~2.10

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
