### PR TITLE
Fix duplicate query on /findJurisdictions

### DIFF
--- a/rest-api/src/main/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionController.java
+++ b/rest-api/src/main/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionController.java
@@ -91,7 +91,12 @@ public class CaseDefinitionController {
             @ApiParam(value = "list of jurisdiction references") @RequestParam("ids") Optional<List<String>> idsOptional) {
 
         LOG.debug("received find jurisdictions request with ids: {}", idsOptional);
-        return idsOptional.map(ids -> jurisdictionService.getAll(ids)).orElse(jurisdictionService.getAll());
+
+        if (idsOptional.isPresent()) {
+            return jurisdictionService.getAll(idsOptional.get());
+        }
+
+        return jurisdictionService.getAll();
     }
 
     @RequestMapping(value = "/data/case-type/{ctid}/version",

--- a/rest-api/src/main/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionController.java
+++ b/rest-api/src/main/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionController.java
@@ -92,11 +92,7 @@ public class CaseDefinitionController {
 
         LOG.debug("received find jurisdictions request with ids: {}", idsOptional);
 
-        if (idsOptional.isPresent()) {
-            return jurisdictionService.getAll(idsOptional.get());
-        }
-
-        return jurisdictionService.getAll();
+        return idsOptional.map(ids -> jurisdictionService.getAll(ids)).orElseGet(jurisdictionService::getAll);
     }
 
     @RequestMapping(value = "/data/case-type/{ctid}/version",

--- a/rest-api/src/test/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionControllerTest.java
+++ b/rest-api/src/test/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionControllerTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -177,6 +178,7 @@ public class CaseDefinitionControllerTest {
         @Test
         public void shouldCallJurisdictionGetAllWhenNoIds() {
             subject.findJurisdictions(Optional.empty());
+            verify(jurisdictionService, times(0)).getAll(anyList());
             verify(jurisdictionService, times(1)).getAll();
         }
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-6603?filter=-3


### Change description ###
This endpoint is frequently called with a list of IDs to retrieve details of specific jurisdictions.

This line would load the requested jurisdictions, then also load every jurisdiction only to throw them away:

`return idsOptional.map(ids -> jurisdictionService.getAll(ids)).orElse(jurisdictionService.getAll());`

Optional.orElse is not lazily evaluated - it is just a java method chain:


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
