### PR TITLE
re enable legacy deployment to fix broken ithc env

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -61,6 +61,5 @@ withPipeline(type, product, app) {
     loadVaultSecrets(secrets)
     enableAksStagingDeployment()
     disableLegacyDeploymentOnAAT()
-    disableLegacyDeployment()
     installCharts()
 }


### PR DESCRIPTION
merge only after approval from Platform Engineering. This is not required if they can fix AKS backends on ITHC