### PR TITLE
RDM-8003: CCD-Definition-store-api -Fix CVEs Spring Framework 5.0.5.R…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.2.4.RELEASE'
+        springBootVersion = '2.2.5.RELEASE'
     }
     dependencies {
         classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7.0.1622"
@@ -227,6 +227,13 @@ subprojects { subproject ->
             exclude group: 'org.hibernate', module: 'hibernate-core'
             exclude group: 'org.hibernate', module: 'hibernate-entitymanager'
         }
+
+        // Force to use the latest org.springframework.security
+        compile group: 'org.springframework.security', name: 'spring-security-core', version: '5.3.0.RELEASE'
+        compile group: 'org.springframework.security', name: 'spring-security-config', version: '5.3.0.RELEASE'
+        compile group: 'org.springframework.security', name: 'spring-security-web', version: '5.3.0.RELEASE'
+        compile group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.3.0.RELEASE'
+
         compile group: 'com.zaxxer', name: 'HikariCP', version: '3.3.1'
         compile group: 'org.jooq', name: 'jool-java-8', version: '0.9.14'
         runtime "org.elasticsearch:elasticsearch:${elasticSearchVersion}"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,11 +2,8 @@
 <suppressions
 	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-	<suppress>
-		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
-			(any version), see https://pivotal.io/security/cve-2018-1258</notes>
-		<cve>CVE-2018-1258</cve>
-	</suppress>
+
+	<!-- THIS WILL BE FIX IN RDM-8007-->
 	<suppress>
 		<notes><![CDATA[
             A permission issue was found in Elasticsearch versions before 5.6.15 and 6.6.1 when Field Level Security and Document Level
@@ -22,6 +19,8 @@
 		<vulnerabilityName>CVE-2019-7611</vulnerabilityName>
 		<vulnerabilityName>CVE-2018-17244</vulnerabilityName>
 	</suppress>
+
+
 	<suppress>
 		<notes><![CDATA[
         The checker is misidentifying our support jar as the elastic search client jar
@@ -35,6 +34,8 @@
 		<cve>CVE-2019-7611</cve>
 		<cve>CVE-2019-7614</cve>
 	</suppress>
+
+	<!-- THIS WILL BE FIX IN RDM-8007-->
 	<!--Liquibase bundles bootstrap and jquery in order to provide an admin 
 		UI Suppressing on the basis that we do not expose this UI. -->
 	<suppress>
@@ -52,15 +53,10 @@
 		<cve>CVE-2015-9251</cve>
 		<cve>CVE-2019-11358</cve>
 	</suppress>
-	<!-- FIXME : RDM-7451 -->
-	<suppress>
-		<notes><![CDATA[
-   relates to spring_framework spring-security
-   ]]></notes>
-		<cpe>cpe:/a:pivotal_software:spring_framework</cpe>
-		<cve>CVE-2020-5398</cve>
-	</suppress>
 
+
+
+	<!-- THIS WILL BE FIX IN RDM-8007-->
 	<suppress>
 		<notes><![CDATA[
    file name: checkstyle-8.18.jar
@@ -70,7 +66,7 @@
 		<cpe>cpe:/a:checkstyle:checkstyle</cpe>
 	</suppress>
 
-	<!-- FIXME : RDM-???? -->
+	<!-- THIS WILL BE FIX IN RDM-8002-->
 	<suppress>
 		<notes>Temporary suppression for on-going developments</notes>
 		<cve>CVE-2020-8840</cve>
@@ -79,6 +75,8 @@
         <cve>CVE-2020-10673</cve>
         <cve>CVE-2020-10672</cve>
 	</suppress>
+
+	<!-- THIS WILL BE FIX IN RDM-8007-->
 	<suppress>
 		<notes><![CDATA[
    file name: tomcat-embed-websocket-9.0.30.jar
@@ -87,6 +85,8 @@
 		</packageUrl>
 		<cve>CVE-2020-1938</cve>
 	</suppress>
+
+	<!-- THIS WILL BE FIX IN RDM-8007-->
 	<suppress>
 		<notes><![CDATA[
    file name: tomcat-embed-core-9.0.30.jar
@@ -95,6 +95,9 @@
 		</packageUrl>
 		<cve>CVE-2020-1938</cve>
 	</suppress>
+
+
+	<!-- THIS WILL BE FIX IN RDM-8002-->
 	<suppress>
 		<notes><![CDATA[
         file name: jackson-databind-2.9.10.3.jar

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions
-	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+		xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
+	<!-- THIS CVEs should not be removed until the elastic search client is updated to 7.
+    Before updating the elastic client make sure that the server has been updated to 7 -->
 
-	<!-- THIS WILL BE FIX IN RDM-8007-->
 	<suppress>
 		<notes><![CDATA[
             A permission issue was found in Elasticsearch versions before 5.6.15 and 6.6.1 when Field Level Security and Document Level
@@ -35,36 +36,6 @@
 		<cve>CVE-2019-7614</cve>
 	</suppress>
 
-	<!-- THIS WILL BE FIX IN RDM-8007-->
-	<!--Liquibase bundles bootstrap and jquery in order to provide an admin 
-		UI Suppressing on the basis that we do not expose this UI. -->
-	<suppress>
-		<notes><![CDATA[ file name: liquibase-core-3.6.3.jar: bootstrap.js ]]></notes>
-		<packageUrl regex="true">^pkg:javascript/bootstrap@.*$
-		</packageUrl>
-		<cve>CVE-2018-14040</cve>
-		<cve>CVE-2018-14041</cve>
-		<cve>CVE-2018-14042</cve>
-		<cve>CVE-2019-8331</cve>
-	</suppress>
-	<suppress>
-		<notes><![CDATA[ file name: liquibase-core-3.6.3.jar: jquery-1.11.0.min.js ]]></notes>
-		<packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
-		<cve>CVE-2015-9251</cve>
-		<cve>CVE-2019-11358</cve>
-	</suppress>
-
-
-
-	<!-- THIS WILL BE FIX IN RDM-8007-->
-	<suppress>
-		<notes><![CDATA[
-   file name: checkstyle-8.18.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/com\.puppycrawl\.tools/checkstyle@.*$
-		</packageUrl>
-		<cpe>cpe:/a:checkstyle:checkstyle</cpe>
-	</suppress>
 
 	<!-- THIS WILL BE FIX IN RDM-8002-->
 	<suppress>
@@ -74,39 +45,16 @@
 		<cve>CVE-2018-17244</cve>
         <cve>CVE-2020-10673</cve>
         <cve>CVE-2020-10672</cve>
+		<cve>CVE-2020-11619</cve>
+		<cve>CVE-2020-11620</cve>
 	</suppress>
 
-	<!-- THIS WILL BE FIX IN RDM-8007-->
+
+
 	<suppress>
-		<notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.30.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-websocket@.*$
-		</packageUrl>
-		<cve>CVE-2020-1938</cve>
+		<notes> NEW CVE og4j-to-slf4j-2.11.1.jar :2.3:a:apache:log4j</notes>
+		<cve>CVE-2020-9488</cve>
 	</suppress>
 
-	<!-- THIS WILL BE FIX IN RDM-8007-->
-	<suppress>
-		<notes><![CDATA[
-   file name: tomcat-embed-core-9.0.30.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-core@.*$
-		</packageUrl>
-		<cve>CVE-2020-1938</cve>
-	</suppress>
-
-
-	<!-- THIS WILL BE FIX IN RDM-8002-->
-	<suppress>
-		<notes><![CDATA[
-        file name: jackson-databind-2.9.10.3.jar
-        ]]></notes>
-		<packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$
-		</packageUrl>
-		<cve>CVE-2020-9546</cve>
-		<cve>CVE-2020-9547</cve>
-		<cve>CVE-2020-9548</cve>
-	</suppress>
 
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -49,7 +49,16 @@
 		<cve>CVE-2020-11620</cve>
 	</suppress>
 
-
+	<suppress>
+		<notes><![CDATA[
+        file name: jackson-databind-2.9.10.3.jar
+        ]]></notes>
+		<packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$
+		</packageUrl>
+		<cve>CVE-2020-9546</cve>
+		<cve>CVE-2020-9547</cve>
+		<cve>CVE-2020-9548</cve>
+	</suppress>
 
 	<suppress>
 		<notes> NEW CVE og4j-to-slf4j-2.11.1.jar :2.3:a:apache:log4j</notes>


### PR DESCRIPTION
 RDM-8003: CCD-Definition-store-api -Fix CVEs Spring Framework 5.0.5.RELEASE / Spring Security libs
    
          [RDM-8003] (https://tools.hmcts.net/jira/browse/RDM-8003).

**Does this PR introduce a breaking change?** (check one with "x")

```
[x ] Yes
[ ] No
```
