### PR TITLE
RDM-8962 - Improve performance of definition importing

### DIFF
--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -111,3 +111,8 @@ ccd.am.write.to_both=${CCD_AM_WRITE_TO_BOTH:}
 ccd.am.read.from_ccd=${CCD_AM_READ_FROM_CCD:AUTOTEST1,TEST}
 ccd.am.read.from_am=${CCD_AM_READ_FROM_AM:}
 
+# Enable batching of inserts and updates
+spring.jpa.properties.hibernate.jdbc.batch_size=100
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.jdbc.batch_versioned_data=true

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParser.java
@@ -43,7 +43,9 @@ class AuthorisationCaseEventParser implements AuthorisationParser {
         validateCaseEvents(definitionSheets, definitionSheet, caseTypeReference);
 
         final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
-        final Map<String, List<DefinitionDataItem>> collect = dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_EVENT_ID)));
+        final Map<String, List<DefinitionDataItem>> collect = dataItems == null
+            ? null
+            : dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_EVENT_ID)));
 
         for (EventEntity event : events) {
             final List<EventACLEntity> parseResults = Lists.newArrayList();

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParser.java
@@ -32,15 +32,10 @@ class AuthorisationCaseEventParser implements AuthorisationParser {
         this.entityToDefinitionDataItemRegistry = registry;
     }
 
-    Collection<EventACLEntity> parseAll(final Map<String, DefinitionSheet> definitionSheets,
-                                        final CaseTypeEntity caseType,
-                                        final EventEntity event) {
-        final List<EventACLEntity> parseResults = Lists.newArrayList();
-
+    void parseAndSetEventACLEntities(final Map<String, DefinitionSheet> definitionSheets,
+                                     final CaseTypeEntity caseType,
+                                     final Collection<EventEntity> events) {
         final String caseTypeReference = caseType.getReference();
-        final String eventReference = event.getReference();
-        LOG.debug("Parsing AuthorisationCaseEvent for case type {}, event {}...", caseTypeReference, eventReference);
-
         DefinitionSheet definitionSheet = getDefinitionSheet(definitionSheets);
 
         final Map<String, List<DefinitionDataItem>> dataItemMap = definitionSheet.groupDataItemsByCaseType();
@@ -48,36 +43,42 @@ class AuthorisationCaseEventParser implements AuthorisationParser {
         validateCaseEvents(definitionSheets, definitionSheet, caseTypeReference);
 
         final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
+        final Map<String, List<DefinitionDataItem>> collect = dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_EVENT_ID)));
 
-        if (null == dataItems) {
-            LOG.warn("No data is found for case type '{} in AuthorisationCaseEvents tab", caseTypeReference);
-        } else {
-            LOG.debug("Parsing user roles for case type {}: {} AuthorisationCaseEvents detected", caseTypeReference, dataItems.size());
+        for (EventEntity event : events) {
+            final List<EventACLEntity> parseResults = Lists.newArrayList();
 
-            final Map<String, List<DefinitionDataItem>> collect = dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_EVENT_ID)));
+            final String eventReference = event.getReference();
+            LOG.debug("Parsing AuthorisationCaseEvent for case type {}, event {}...", caseTypeReference, eventReference);
 
-            if (null == collect.get(eventReference)) {
-                LOG.warn("No row is defined for case type '{}', event '{}'", caseTypeReference, eventReference);
-                // and let validation handles this Exception
+            if (null == dataItems) {
+                LOG.warn("No data is found for case type '{} in AuthorisationCaseEvents tab", caseTypeReference);
             } else {
-                for (DefinitionDataItem definition : collect.get(eventReference)) {
-                    EventACLEntity entity = new EventACLEntity();
+                LOG.debug("Parsing user roles for case type {}: {} AuthorisationCaseEvents detected", caseTypeReference, dataItems.size());
 
-                    parseUserRole(entity, definition, parseContext);
-                    parseCrud(entity, definition);
-                    parseResults.add(entity);
-                    entityToDefinitionDataItemRegistry.addDefinitionDataItemForEntity(entity, definition);
+                if (null == collect.get(eventReference)) {
+                    LOG.warn("No row is defined for case type '{}', event '{}'", caseTypeReference, eventReference);
+                    // and let validation handles this Exception
+                } else {
+                    for (DefinitionDataItem definition : collect.get(eventReference)) {
+                        EventACLEntity entity = new EventACLEntity();
 
-                    LOG.info("Parsing user role for case type '{}', event '{}', user role '{}', crud '{}': OK",
-                        caseTypeReference,
-                        eventReference,
-                        definition.getString(ColumnName.USER_ROLE),
-                        definition.getString(ColumnName.CRUD));
+                        parseUserRole(entity, definition, parseContext);
+                        parseCrud(entity, definition);
+                        parseResults.add(entity);
+                        entityToDefinitionDataItemRegistry.addDefinitionDataItemForEntity(entity, definition);
+
+                        LOG.info("Parsing user role for case type '{}', event '{}', user role '{}', crud '{}': OK",
+                            caseTypeReference,
+                            eventReference,
+                            definition.getString(ColumnName.USER_ROLE),
+                            definition.getString(ColumnName.CRUD));
+                    }
                 }
             }
-        }
 
-        return parseResults;
+            event.addEventACLEntities(parseResults);
+        }
     }
 
     private void validateCaseEvents(Map<String, DefinitionSheet> definitionSheets, DefinitionSheet definitionSheet, String caseTypeReference) {

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParser.java
@@ -28,9 +28,9 @@ class AuthorisationCaseFieldParser implements AuthorisationParser {
         this.entityToDefinitionDataItemRegistry = registry;
     }
 
-    void addACLEntities(final Map<String, DefinitionSheet> definitionSheets,
-                                                              final CaseTypeEntity caseType,
-                                                              final Collection<CaseFieldEntity> caseFields) {
+    void parseAndSetACLEntities(final Map<String, DefinitionSheet> definitionSheets,
+                                final CaseTypeEntity caseType,
+                                final Collection<CaseFieldEntity> caseFields) {
         DefinitionSheet definitionSheet = getDefinitionSheet(definitionSheets);
         final Map<String, List<DefinitionDataItem>> dataItemMap = definitionSheet.groupDataItemsByCaseType();
         validateCaseTypes(definitionSheets, dataItemMap);
@@ -38,16 +38,15 @@ class AuthorisationCaseFieldParser implements AuthorisationParser {
         validateCaseFields(definitionSheets, definitionSheet, caseTypeReference);
 
         final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
-        final Map<String, List<DefinitionDataItem>> collect = dataItems
-            .stream()
-            .collect(groupingBy(d -> d.getString(ColumnName.CASE_FIELD_ID)));
+        final Map<String, List<DefinitionDataItem>> collect = dataItems == null
+            ? null
+            : dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_FIELD_ID)));
 
         for (CaseFieldEntity caseField : caseFields) {
             final List<CaseFieldACLEntity> parseResults = Lists.newArrayList();
             final String caseFieldReference = caseField.getReference();
             LOG.debug("Parsing AuthorisationCaseField for case type {}, caseField {}...",
                 caseTypeReference, caseFieldReference);
-
 
             if (null == dataItems) {
                 LOG.warn("No data is found for case type '{} in AuthorisationCaseFields tab", caseTypeReference);

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParser.java
@@ -28,57 +28,57 @@ class AuthorisationCaseFieldParser implements AuthorisationParser {
         this.entityToDefinitionDataItemRegistry = registry;
     }
 
-    Collection<CaseFieldACLEntity> parseAll(final Map<String, DefinitionSheet> definitionSheets,
-                                            final CaseTypeEntity caseType,
-                                            final CaseFieldEntity caseField) {
-        final List<CaseFieldACLEntity> parseResults = Lists.newArrayList();
-
-        final String caseTypeReference = caseType.getReference();
-        final String caseFieldReference = caseField.getReference();
-        LOG.debug("Parsing AuthorisationCaseField for case type {}, caseField {}...",
-            caseTypeReference, caseFieldReference);
-
+    void addACLEntities(final Map<String, DefinitionSheet> definitionSheets,
+                                                              final CaseTypeEntity caseType,
+                                                              final Collection<CaseFieldEntity> caseFields) {
         DefinitionSheet definitionSheet = getDefinitionSheet(definitionSheets);
-
         final Map<String, List<DefinitionDataItem>> dataItemMap = definitionSheet.groupDataItemsByCaseType();
         validateCaseTypes(definitionSheets, dataItemMap);
+        final String caseTypeReference = caseType.getReference();
         validateCaseFields(definitionSheets, definitionSheet, caseTypeReference);
 
         final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
+        final Map<String, List<DefinitionDataItem>> collect = dataItems
+            .stream()
+            .collect(groupingBy(d -> d.getString(ColumnName.CASE_FIELD_ID)));
 
-        if (null == dataItems) {
-            LOG.warn("No data is found for case type '{} in AuthorisationCaseFields tab", caseTypeReference);
-        } else {
-            LOG.debug("Parsing user roles for case type '{}': '{}' AuthorisationCaseFields detected",
-                caseTypeReference, dataItems.size());
+        for (CaseFieldEntity caseField : caseFields) {
+            final List<CaseFieldACLEntity> parseResults = Lists.newArrayList();
+            final String caseFieldReference = caseField.getReference();
+            LOG.debug("Parsing AuthorisationCaseField for case type {}, caseField {}...",
+                caseTypeReference, caseFieldReference);
 
-            final Map<String, List<DefinitionDataItem>> collect = dataItems
-                .stream()
-                .collect(groupingBy(d -> d.getString(ColumnName.CASE_FIELD_ID)));
 
-            if (null == collect.get(caseFieldReference)) {
-                LOG.warn("No row is defined for case type '{}', case field '{}'", caseTypeReference, caseFieldReference);
-                // and let validation handles this Exception
+            if (null == dataItems) {
+                LOG.warn("No data is found for case type '{} in AuthorisationCaseFields tab", caseTypeReference);
             } else {
-                for (DefinitionDataItem definition : collect.get(caseFieldReference)) {
+                LOG.debug("Parsing user roles for case type '{}': '{}' AuthorisationCaseFields detected",
+                    caseTypeReference, dataItems.size());
 
-                    final CaseFieldACLEntity entity = new CaseFieldACLEntity();
+                if (null == collect.get(caseFieldReference)) {
+                    LOG.warn("No row is defined for case type '{}', case field '{}'", caseTypeReference, caseFieldReference);
+                    // and let validation handles this Exception
+                } else {
+                    for (DefinitionDataItem definition : collect.get(caseFieldReference)) {
 
-                    parseUserRole(entity, definition, parseContext);
-                    parseCrud(entity, definition);
-                    parseResults.add(entity);
-                    entityToDefinitionDataItemRegistry.addDefinitionDataItemForEntity(entity, definition);
+                        final CaseFieldACLEntity entity = new CaseFieldACLEntity();
 
-                    LOG.info("Parsing user role for case type '{}', case field '{}', user role '{}', crud '{}': OK",
-                        caseTypeReference,
-                        definition.getString(ColumnName.CASE_FIELD_ID),
-                        definition.getString(ColumnName.USER_ROLE),
-                        definition.getString(ColumnName.CRUD));
+                        parseUserRole(entity, definition, parseContext);
+                        parseCrud(entity, definition);
+                        parseResults.add(entity);
+                        entityToDefinitionDataItemRegistry.addDefinitionDataItemForEntity(entity, definition);
+
+                        LOG.info("Parsing user role for case type '{}', case field '{}', user role '{}', crud '{}': OK",
+                            caseTypeReference,
+                            definition.getString(ColumnName.CASE_FIELD_ID),
+                            definition.getString(ColumnName.USER_ROLE),
+                            definition.getString(ColumnName.CRUD));
+                    }
                 }
             }
-        }
 
-        return parseResults;
+            caseField.addCaseACLEntities(parseResults);
+        }
     }
 
     @Override

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/CaseTypeParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/CaseTypeParser.java
@@ -8,13 +8,9 @@ import uk.gov.hmcts.ccd.definition.store.excel.parser.model.DefinitionSheet;
 import uk.gov.hmcts.ccd.definition.store.excel.parser.model.SecurityClassificationColumn;
 import uk.gov.hmcts.ccd.definition.store.excel.util.mapper.ColumnName;
 import uk.gov.hmcts.ccd.definition.store.excel.util.mapper.SheetName;
-import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseFieldACLEntity;
-import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseFieldEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseRoleEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseTypeACLEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.CaseTypeEntity;
-import uk.gov.hmcts.ccd.definition.store.repository.entity.EventACLEntity;
-import uk.gov.hmcts.ccd.definition.store.repository.entity.EventEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.StateACLEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.StateEntity;
 import uk.gov.hmcts.ccd.definition.store.repository.entity.WebhookEntity;
@@ -104,10 +100,7 @@ public class CaseTypeParser {
             authorisationComplexTypeParser.parseAll(definitionSheets, caseType);
 
 
-            for (EventEntity event : caseType.getEvents()) {
-                Collection<EventACLEntity> eventACLEntities = authorisationCaseEventParser.parseAll(definitionSheets, caseType, event);
-                event.addEventACLEntities(eventACLEntities);
-            }
+            authorisationCaseEventParser.parseAndSetEventACLEntities(definitionSheets, caseType, caseType.getEvents());
 
             for (StateEntity stateEntity : caseType.getStates()) {
                 Collection<StateACLEntity> stateACLEntities = authorisationCaseStateParser.parseAll(definitionSheets, caseType, stateEntity);

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/CaseTypeParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/CaseTypeParser.java
@@ -95,10 +95,9 @@ public class CaseTypeParser {
             Collection<CaseTypeACLEntity> caseTypeACLEntities = authorisationCaseTypeParser.parseAll(definitionSheets, caseType);
             caseType.addCaseTypeACLEntities(caseTypeACLEntities);
 
-            authorisationCaseFieldParser.addACLEntities(definitionSheets, caseType, caseType.getCaseFields());
+            authorisationCaseFieldParser.parseAndSetACLEntities(definitionSheets, caseType, caseType.getCaseFields());
 
             authorisationComplexTypeParser.parseAll(definitionSheets, caseType);
-
 
             authorisationCaseEventParser.parseAndSetEventACLEntities(definitionSheets, caseType, caseType.getEvents());
 

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/CaseTypeParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/CaseTypeParser.java
@@ -99,10 +99,7 @@ public class CaseTypeParser {
             Collection<CaseTypeACLEntity> caseTypeACLEntities = authorisationCaseTypeParser.parseAll(definitionSheets, caseType);
             caseType.addCaseTypeACLEntities(caseTypeACLEntities);
 
-            for (CaseFieldEntity caseField : caseType.getCaseFields()) {
-                Collection<CaseFieldACLEntity> caseFieldACLEntities = authorisationCaseFieldParser.parseAll(definitionSheets, caseType, caseField);
-                caseField.addCaseACLEntities(caseFieldACLEntities);
-            }
+            authorisationCaseFieldParser.addACLEntities(definitionSheets, caseType, caseType.getCaseFields());
 
             authorisationComplexTypeParser.parseAll(definitionSheets, caseType);
 

--- a/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParserTest.java
+++ b/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParserTest.java
@@ -80,7 +80,8 @@ class AuthorisationCaseEventParserTest {
         item1.addAttribute(ColumnName.USER_ROLE.toString(), role);
         item1.addAttribute(ColumnName.CRUD.toString(), " CCCd  ");
         definitionSheet.addDataItem(item1);
-        final Collection<EventACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseEvent);
+        subject.parseAndSetEventACLEntities(definitionSheets, caseType, Collections.singleton(caseEvent));
+        Collection<EventACLEntity> entities = caseEvent.getEventACLEntities();
         assertThat(entities.size(), is(1));
 
         final EventACLEntity eventACLEntity = new ArrayList<>(entities).get(0);
@@ -106,7 +107,8 @@ class AuthorisationCaseEventParserTest {
         item1.addAttribute(ColumnName.USER_ROLE.toString(), caseRole);
         item1.addAttribute(ColumnName.CRUD.toString(), " CCCd  ");
         definitionSheet.addDataItem(item1);
-        final Collection<EventACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseEvent);
+        subject.parseAndSetEventACLEntities(definitionSheets, caseType, Collections.singleton(caseEvent));
+        Collection<EventACLEntity> entities = caseEvent.getEventACLEntities();
         assertThat(entities.size(), is(1));
 
         final EventACLEntity eventACLEntity = new ArrayList<>(entities).get(0);
@@ -133,7 +135,8 @@ class AuthorisationCaseEventParserTest {
         item1.addAttribute(ColumnName.USER_ROLE.toString(), role);
         item1.addAttribute(ColumnName.CRUD.toString(), " CCCd  ");
         definitionSheet.addDataItem(item1);
-        final Collection<EventACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseEvent);
+        subject.parseAndSetEventACLEntities(definitionSheets, caseType, Collections.singleton(caseEvent));
+        Collection<EventACLEntity> entities = caseEvent.getEventACLEntities();
         assertThat(entities.size(), is(1));
 
         final EventACLEntity eventACLEntity = new ArrayList<>(entities).get(0);
@@ -156,7 +159,9 @@ class AuthorisationCaseEventParserTest {
         item1.addAttribute(ColumnName.USER_ROLE.toString(), role);
         item1.addAttribute(ColumnName.CRUD.toString(), " X y  ");
         definitionSheet.addDataItem(item1);
-        final Collection<EventACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseEvent);
+        subject.parseAndSetEventACLEntities(definitionSheets, caseType, Collections.singleton(caseEvent));
+        Collection<EventACLEntity> entities = caseEvent.getEventACLEntities();
+
         assertThat(entities.size(), is(1));
 
         final EventACLEntity eventACLEntity = new ArrayList<>(entities).get(0);
@@ -178,7 +183,9 @@ class AuthorisationCaseEventParserTest {
         item1.addAttribute(ColumnName.USER_ROLE.toString(), role);
         item1.addAttribute(ColumnName.CRUD.toString(), " X y  ");
         definitionSheet.addDataItem(item1);
-        final Collection<EventACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseEvent);
+        subject.parseAndSetEventACLEntities(definitionSheets, caseType, Collections.singleton(caseEvent));
+        Collection<EventACLEntity> entities = caseEvent.getEventACLEntities();
+
         assertThat(entities.size(), is(1));
 
         final EventACLEntity eventACLEntity = new ArrayList<>(entities).get(0);

--- a/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParserTest.java
+++ b/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParserTest.java
@@ -75,7 +75,7 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        subject.parseAndSetACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
         Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 
@@ -102,7 +102,7 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        subject.parseAndSetACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
         final Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 
@@ -129,7 +129,7 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        subject.parseAndSetACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
         Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 
@@ -152,7 +152,7 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        subject.parseAndSetACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
         Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 
@@ -175,7 +175,7 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        subject.parseAndSetACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
         final Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 

--- a/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParserTest.java
+++ b/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParserTest.java
@@ -75,7 +75,8 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        final Collection<CaseFieldACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseField);
+        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 
         final CaseFieldACLEntity caseFieldACLEntity = new ArrayList<>(entities).get(0);
@@ -101,7 +102,8 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        final Collection<CaseFieldACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseField);
+        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        final Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 
         final CaseFieldACLEntity caseFieldACLEntity = new ArrayList<>(entities).get(0);
@@ -127,7 +129,8 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        final Collection<CaseFieldACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseField);
+        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 
         final CaseFieldACLEntity caseFieldACLEntity = new ArrayList<>(entities).get(0);
@@ -149,7 +152,8 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        final Collection<CaseFieldACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseField);
+        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 
         final CaseFieldACLEntity caseFieldACLEntity = new ArrayList<>(entities).get(0);
@@ -171,7 +175,8 @@ public class AuthorisationCaseFieldParserTest {
         item1.addAttribute(CASE_FIELD_ID.toString(), CASE_FIELD_UNDER_TEST);
 
         definitionSheet.addDataItem(item1);
-        final Collection<CaseFieldACLEntity> entities = subject.parseAll(definitionSheets, caseType, caseField);
+        subject.addACLEntities(definitionSheets, caseType, Collections.singleton(caseField));
+        final Collection<CaseFieldACLEntity> entities = caseField.getCaseFieldACLEntities();
         assertThat(entities.size(), is(1));
 
         final CaseFieldACLEntity caseFieldACLEntity = new ArrayList<>(entities).get(0);

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
@@ -16,8 +16,8 @@ public abstract class Authorisation implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "acl_generator")
-    @SequenceGenerator(name="acl_generator", sequenceName = "case_field_acl_id_seq", allocationSize=50)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "case_field_acl_id_seq")
+    @SequenceGenerator(name = "case_field_acl_id_seq")
     private Integer id;
 
     @NotNull

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
@@ -17,7 +17,6 @@ public abstract class Authorisation implements Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "case_field_acl_id_seq")
-    @SequenceGenerator(name = "case_field_acl_id_seq")
     private Integer id;
 
     @NotNull

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.GenerationType.SEQUENCE;
 
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -17,7 +18,8 @@ public abstract class Authorisation implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "acl_generator")
+    @SequenceGenerator(name="acl_generator", sequenceName = "case_field_acl_id_seq", allocationSize=50)
     private Integer id;
 
     @NotNull

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.ccd.definition.store.repository.entity;
 
+import org.hibernate.annotations.CreationTimestamp;
+
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
@@ -8,10 +10,6 @@ import java.time.LocalDateTime;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static javax.persistence.GenerationType.IDENTITY;
-import static javax.persistence.GenerationType.SEQUENCE;
-
-import org.hibernate.annotations.CreationTimestamp;
 
 @MappedSuperclass
 public abstract class Authorisation implements Serializable {

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/Authorisation.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.ccd.definition.store.repository.entity;
 
-import org.hibernate.annotations.CreationTimestamp;
-
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
@@ -10,6 +8,8 @@ import java.time.LocalDateTime;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+
+import org.hibernate.annotations.CreationTimestamp;
 
 @MappedSuperclass
 public abstract class Authorisation implements Serializable {

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
@@ -1,18 +1,33 @@
 package uk.gov.hmcts.ccd.definition.store.repository.entity;
 
-import org.apache.commons.lang3.StringUtils;
-import org.hibernate.annotations.Parameter;
-import org.hibernate.annotations.*;
-import uk.gov.hmcts.ccd.definition.store.repository.PostgreSQLEnumType;
-import uk.gov.hmcts.ccd.definition.store.repository.SecurityClassification;
-
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import javax.persistence.*;
+import javax.persistence.Transient;
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
+import uk.gov.hmcts.ccd.definition.store.repository.PostgreSQLEnumType;
+import uk.gov.hmcts.ccd.definition.store.repository.SecurityClassification;
 
 import static javax.persistence.CascadeType.ALL;
 import static javax.persistence.FetchType.EAGER;

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
@@ -7,7 +7,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import java.io.Serializable;
@@ -54,7 +53,6 @@ public class CaseFieldEntity implements FieldEntity, Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = SEQUENCE, generator = "case_field_id_seq")
-    @SequenceGenerator(name = "case_field_id_seq")
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
@@ -1,29 +1,22 @@
 package uk.gov.hmcts.ccd.definition.store.repository.entity;
 
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.*;
+import uk.gov.hmcts.ccd.definition.store.repository.PostgreSQLEnumType;
+import uk.gov.hmcts.ccd.definition.store.repository.SecurityClassification;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.Parameter;
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
-import org.hibernate.annotations.TypeDefs;
-import uk.gov.hmcts.ccd.definition.store.repository.PostgreSQLEnumType;
-import uk.gov.hmcts.ccd.definition.store.repository.SecurityClassification;
 
 import static javax.persistence.CascadeType.ALL;
 import static javax.persistence.FetchType.EAGER;
 import static javax.persistence.FetchType.LAZY;
-import static javax.persistence.GenerationType.IDENTITY;
 import static javax.persistence.GenerationType.SEQUENCE;
 
 @Table(name = "case_field")
@@ -79,9 +72,8 @@ public class CaseFieldEntity implements FieldEntity, Serializable {
     @JoinColumn(name = "case_type_id", nullable = false)
     private CaseTypeEntity caseType;
 
-    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true)
+    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true, mappedBy = "caseField")
     @Fetch(value = FetchMode.SUBSELECT)
-    @JoinColumn(name = "case_field_id")
     private final List<CaseFieldACLEntity> caseFieldACLEntities = new ArrayList<>();
 
     @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
@@ -38,8 +38,8 @@ public class CaseFieldEntity implements FieldEntity, Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = SEQUENCE, generator = "case_field_generator")
-    @SequenceGenerator(name="case_field_generator", sequenceName = "case_field_id_seq", allocationSize = 50)
+    @GeneratedValue(strategy = SEQUENCE, generator = "case_field_id_seq")
+    @SequenceGenerator(name = "case_field_id_seq")
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseFieldEntity.java
@@ -1,14 +1,6 @@
 package uk.gov.hmcts.ccd.definition.store.repository.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import javax.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -32,6 +24,7 @@ import static javax.persistence.CascadeType.ALL;
 import static javax.persistence.FetchType.EAGER;
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.GenerationType.SEQUENCE;
 
 @Table(name = "case_field")
 @Entity
@@ -52,7 +45,8 @@ public class CaseFieldEntity implements FieldEntity, Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = IDENTITY)
+    @GeneratedValue(strategy = SEQUENCE, generator = "case_field_generator")
+    @SequenceGenerator(name="case_field_generator", sequenceName = "case_field_id_seq", allocationSize = 50)
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseTypeEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/CaseTypeEntity.java
@@ -80,9 +80,8 @@ public class CaseTypeEntity implements Serializable, Versionable {
     @JoinColumn(name = "jurisdiction_id", nullable = false)
     private JurisdictionEntity jurisdiction;
 
-    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true)
+    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true, mappedBy = "caseType")
     @Fetch(value = FetchMode.SUBSELECT)
-    @JoinColumn(name = "case_type_id")
     private final List<EventEntity> events = new ArrayList<>();
 
     @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true)
@@ -90,9 +89,8 @@ public class CaseTypeEntity implements Serializable, Versionable {
     @JoinColumn(name = "case_type_id")
     private final List<StateEntity> states = new ArrayList<>();
 
-    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true)
+    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true, mappedBy = "caseType")
     @Fetch(value = FetchMode.SUBSELECT)
-    @JoinColumn(name = "case_type_id")
     private final List<CaseFieldEntity> caseFields = new ArrayList<>();
 
     @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/ComplexFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/ComplexFieldEntity.java
@@ -23,7 +23,6 @@ public class ComplexFieldEntity implements FieldEntity, Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = SEQUENCE, generator = "complex_field_id_seq")
-    @SequenceGenerator(name = "complex_field_id_seq")
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/ComplexFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/ComplexFieldEntity.java
@@ -22,8 +22,8 @@ public class ComplexFieldEntity implements FieldEntity, Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = SEQUENCE, generator = "complex_field_generator")
-    @SequenceGenerator(name = "complex_field_generator", sequenceName = "complex_field_id_seq")
+    @GeneratedValue(strategy = SEQUENCE, generator = "complex_field_id_seq")
+    @SequenceGenerator(name = "complex_field_id_seq")
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/ComplexFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/ComplexFieldEntity.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.ccd.definition.store.repository.entity;
 import javax.persistence.*;
 import java.io.Serializable;
 
-import static javax.persistence.GenerationType.IDENTITY;
 import static javax.persistence.GenerationType.SEQUENCE;
 
 import org.hibernate.annotations.Parameter;

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/ComplexFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/ComplexFieldEntity.java
@@ -4,6 +4,7 @@ import javax.persistence.*;
 import java.io.Serializable;
 
 import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.GenerationType.SEQUENCE;
 
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
@@ -22,7 +23,8 @@ public class ComplexFieldEntity implements FieldEntity, Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = IDENTITY)
+    @GeneratedValue(strategy = SEQUENCE, generator = "complex_field_generator")
+    @SequenceGenerator(name = "complex_field_generator", sequenceName = "complex_field_id_seq")
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupCaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupCaseFieldEntity.java
@@ -14,7 +14,6 @@ public class DisplayGroupCaseFieldEntity implements Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "display_group_case_field_id_seq")
-    @SequenceGenerator(name = "display_group_case_field_id_seq")
     private Integer id;
 
     @Column(name = "live_from")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupCaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupCaseFieldEntity.java
@@ -13,7 +13,8 @@ public class DisplayGroupCaseFieldEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "display_group_case_field_generator")
+    @SequenceGenerator(name="display_group_case_field_generator", sequenceName = "display_group_case_field_id_seq", allocationSize=50)
     private Integer id;
 
     @Column(name = "live_from")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupCaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupCaseFieldEntity.java
@@ -13,8 +13,8 @@ public class DisplayGroupCaseFieldEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "display_group_case_field_generator")
-    @SequenceGenerator(name="display_group_case_field_generator", sequenceName = "display_group_case_field_id_seq", allocationSize=50)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "display_group_case_field_id_seq")
+    @SequenceGenerator(name = "display_group_case_field_id_seq")
     private Integer id;
 
     @Column(name = "live_from")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupEntity.java
@@ -20,7 +20,8 @@ public class DisplayGroupEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "display_group_generator")
+    @SequenceGenerator(name="display_group_generator", sequenceName = "display_group_id_seq", allocationSize=50)
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupEntity.java
@@ -21,7 +21,6 @@ public class DisplayGroupEntity implements Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "display_group_id_seq")
-    @SequenceGenerator(name = "display_group_id_seq")
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/DisplayGroupEntity.java
@@ -20,8 +20,8 @@ public class DisplayGroupEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "display_group_generator")
-    @SequenceGenerator(name="display_group_generator", sequenceName = "display_group_id_seq", allocationSize=50)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "display_group_id_seq")
+    @SequenceGenerator(name = "display_group_id_seq")
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventCaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventCaseFieldEntity.java
@@ -7,7 +7,17 @@ import org.hibernate.annotations.TypeDef;
 import uk.gov.hmcts.ccd.definition.store.repository.DisplayContext;
 import uk.gov.hmcts.ccd.definition.store.repository.PostgreSQLEnumType;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventCaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventCaseFieldEntity.java
@@ -25,8 +25,8 @@ import static javax.persistence.FetchType.EAGER;
 public class EventCaseFieldEntity implements Serializable {
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_case_field_generator")
-    @SequenceGenerator(name="event_case_field_generator", sequenceName = "event_case_field_id_seq", allocationSize=50)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_case_field_id_seq")
+    @SequenceGenerator(name = "event_case_field_id_seq")
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventCaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventCaseFieldEntity.java
@@ -7,16 +7,7 @@ import org.hibernate.annotations.TypeDef;
 import uk.gov.hmcts.ccd.definition.store.repository.DisplayContext;
 import uk.gov.hmcts.ccd.definition.store.repository.PostgreSQLEnumType;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +25,8 @@ import static javax.persistence.FetchType.EAGER;
 public class EventCaseFieldEntity implements Serializable {
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_case_field_generator")
+    @SequenceGenerator(name="event_case_field_generator", sequenceName = "event_case_field_id_seq", allocationSize=50)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventCaseFieldEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventCaseFieldEntity.java
@@ -16,7 +16,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -36,7 +35,6 @@ public class EventCaseFieldEntity implements Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_case_field_id_seq")
-    @SequenceGenerator(name = "event_case_field_id_seq")
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventEntity.java
@@ -93,9 +93,8 @@ public class EventEntity implements Serializable {
     @Fetch(value = SUBSELECT)
     private final List<EventCaseFieldEntity> eventCaseFields = new ArrayList<>();
 
-    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true)
+    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true, mappedBy = "event")
     @Fetch(value = FetchMode.SUBSELECT)
-    @JoinColumn(name = "event_id")
     private final List<EventACLEntity> eventACLEntities = new ArrayList<>();
 
     @Column(name = "show_event_notes")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventEntity.java
@@ -31,7 +31,8 @@ public class EventEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_generator")
+    @SequenceGenerator(name="event_generator", sequenceName = "event_id_seq", allocationSize=50)
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventEntity.java
@@ -31,8 +31,8 @@ public class EventEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_generator")
-    @SequenceGenerator(name="event_generator", sequenceName = "event_id_seq", allocationSize=50)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_id_seq")
+    @SequenceGenerator(name = "event_id_seq")
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventEntity.java
@@ -32,7 +32,6 @@ public class EventEntity implements Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_id_seq")
-    @SequenceGenerator(name = "event_id_seq")
     private Integer id;
 
     @Column(name = "reference", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventWebhookEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventWebhookEntity.java
@@ -25,8 +25,8 @@ public class EventWebhookEntity {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_webhook_generator")
-    @SequenceGenerator(name="event_webhook_generator", sequenceName = "event_webhook_id_seq", allocationSize=50)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_webhook_id_seq")
+    @SequenceGenerator(name = "event_webhook_id_seq")
     private Integer id;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventWebhookEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventWebhookEntity.java
@@ -25,7 +25,8 @@ public class EventWebhookEntity {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_webhook_generator")
+    @SequenceGenerator(name="event_webhook_generator", sequenceName = "event_webhook_id_seq", allocationSize=50)
     private Integer id;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventWebhookEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/EventWebhookEntity.java
@@ -26,7 +26,6 @@ public class EventWebhookEntity {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "event_webhook_id_seq")
-    @SequenceGenerator(name = "event_webhook_id_seq")
     private Integer id;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeEntity.java
@@ -1,17 +1,6 @@
 package uk.gov.hmcts.ccd.definition.store.repository.entity;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OrderBy;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import javax.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -23,6 +12,7 @@ import java.util.UUID;
 
 import static java.util.Collections.emptyList;
 import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.GenerationType.SEQUENCE;
 import static uk.gov.hmcts.ccd.definition.store.repository.FieldTypeUtils.BASE_COLLECTION;
 import static uk.gov.hmcts.ccd.definition.store.repository.FieldTypeUtils.BASE_COMPLEX;
 import static uk.gov.hmcts.ccd.definition.store.repository.FieldTypeUtils.BASE_DOCUMENT;
@@ -40,7 +30,8 @@ public class FieldTypeEntity implements Serializable, Versionable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = IDENTITY)
+    @GeneratedValue(strategy = SEQUENCE, generator = "field_type_generator")
+    @SequenceGenerator(name = "field_type_generator", sequenceName = "field_type_id_seq")
     private Integer id;
 
     @Column(name = "created_at")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeEntity.java
@@ -30,8 +30,8 @@ public class FieldTypeEntity implements Serializable, Versionable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = SEQUENCE, generator = "field_type_generator")
-    @SequenceGenerator(name = "field_type_generator", sequenceName = "field_type_id_seq")
+    @GeneratedValue(strategy = SEQUENCE, generator = "field_type_id_seq")
+    @SequenceGenerator(name = "field_type_id_seq")
     private Integer id;
 
     @Column(name = "created_at")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeEntity.java
@@ -10,7 +10,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
-import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import java.io.Serializable;
@@ -42,7 +41,6 @@ public class FieldTypeEntity implements Serializable, Versionable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = SEQUENCE, generator = "field_type_id_seq")
-    @SequenceGenerator(name = "field_type_id_seq")
     private Integer id;
 
     @Column(name = "created_at")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeEntity.java
@@ -1,6 +1,18 @@
 package uk.gov.hmcts.ccd.definition.store.repository.entity;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Transient;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -11,7 +23,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import static java.util.Collections.emptyList;
-import static javax.persistence.GenerationType.IDENTITY;
 import static javax.persistence.GenerationType.SEQUENCE;
 import static uk.gov.hmcts.ccd.definition.store.repository.FieldTypeUtils.BASE_COLLECTION;
 import static uk.gov.hmcts.ccd.definition.store.repository.FieldTypeUtils.BASE_COMPLEX;

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeListItemEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeListItemEntity.java
@@ -12,7 +12,6 @@ public class FieldTypeListItemEntity implements Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = SEQUENCE, generator = "field_type_list_item_id_seq")
-    @SequenceGenerator(name = "field_type_list_item_id_seq")
     private Integer id;
 
     @Column(name = "value", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeListItemEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeListItemEntity.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.ccd.definition.store.repository.entity;
 import javax.persistence.*;
 import java.io.Serializable;
 
-import static javax.persistence.GenerationType.IDENTITY;
 import static javax.persistence.GenerationType.SEQUENCE;
 
 @Table(name = "field_type_list_item")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeListItemEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeListItemEntity.java
@@ -12,8 +12,8 @@ public class FieldTypeListItemEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = SEQUENCE, generator = "field_type_list_item_generator")
-    @SequenceGenerator(name = "field_type_list_item_generator", sequenceName = "field_type_list_item_id_seq")
+    @GeneratedValue(strategy = SEQUENCE, generator = "field_type_list_item_id_seq")
+    @SequenceGenerator(name = "field_type_list_item_id_seq")
     private Integer id;
 
     @Column(name = "value", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeListItemEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/FieldTypeListItemEntity.java
@@ -4,6 +4,7 @@ import javax.persistence.*;
 import java.io.Serializable;
 
 import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.GenerationType.SEQUENCE;
 
 @Table(name = "field_type_list_item")
 @Entity
@@ -11,7 +12,8 @@ public class FieldTypeListItemEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = IDENTITY)
+    @GeneratedValue(strategy = SEQUENCE, generator = "field_type_list_item_generator")
+    @SequenceGenerator(name = "field_type_list_item_generator", sequenceName = "field_type_list_item_id_seq")
     private Integer id;
 
     @Column(name = "value", nullable = false)

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/StateEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/StateEntity.java
@@ -44,9 +44,8 @@ public class StateEntity implements Serializable, Referencable {
     @JoinColumn(name = "case_type_id", nullable = false)
     private CaseTypeEntity caseType;
 
-    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true)
+    @OneToMany(fetch = EAGER, cascade = ALL, orphanRemoval = true, mappedBy = "stateEntity")
     @Fetch(value = FetchMode.SUBSELECT)
-    @JoinColumn(name = "state_id")
     private final List<StateACLEntity> stateACLEntities = new ArrayList<>();
 
     @Column(name = "title_display")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/WebhookEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/WebhookEntity.java
@@ -24,7 +24,6 @@ public class WebhookEntity implements Serializable {
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhook_id_seq")
-    @SequenceGenerator(name = "webhook_id_seq")
     private Integer id;
 
     @Column(name = "url")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/WebhookEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/WebhookEntity.java
@@ -23,8 +23,8 @@ public class WebhookEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhook_generator")
-    @SequenceGenerator(name="webhook_generator", sequenceName = "webhook_id_seq", allocationSize=50)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhook_id_seq")
+    @SequenceGenerator(name = "webhook_id_seq")
     private Integer id;
 
     @Column(name = "url")

--- a/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/WebhookEntity.java
+++ b/repository/src/main/java/uk/gov/hmcts/ccd/definition/store/repository/entity/WebhookEntity.java
@@ -23,7 +23,8 @@ public class WebhookEntity implements Serializable {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "webhook_generator")
+    @SequenceGenerator(name="webhook_generator", sequenceName = "webhook_id_seq", allocationSize=50)
     private Integer id;
 
     @Column(name = "url")

--- a/repository/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-master.xml
@@ -87,4 +87,5 @@
     <include file="db/changelog/db.changelog-rdm-8127.xml"/>
     <include file="db/changelog/db.changelog-rdm-8359.xml"/>
     <include file="db/changelog/db.changelog-rdm-8509.xml"/>
+    <include file="db/changelog/db.changelog-rdm-8692.xml"/>
 </databaseChangeLog>

--- a/repository/src/main/resources/db/changelog/db.changelog-rdm-8692.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-rdm-8692.xml
@@ -16,8 +16,6 @@
             ALTER SEQUENCE display_group_id_seq increment by 50;
             ALTER SEQUENCE webhook_id_seq increment by 50;
             ALTER SEQUENCE event_webhook_id_seq increment by 50;
-
-
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/repository/src/main/resources/db/changelog/db.changelog-rdm-8692.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-rdm-8692.xml
@@ -1,0 +1,19 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="rdm-8692-improve-import-perf" author="alex.mcausland@hmcts.net">
+<!--        An increment of 50 allows hibernate to preallocate identifiers for use in creating-->
+<!--        new entities, rather than having to do a database round trip each time.-->
+        <sql>
+            ALTER SEQUENCE case_field_acl_id_seq increment by 50;
+            ALTER SEQUENCE case_field_id_seq increment by 50;
+            ALTER SEQUENCE complex_field_id_seq increment by 50;
+            ALTER SEQUENCE display_group_case_field_id_seq increment by 50;
+            ALTER SEQUENCE event_case_field_id_seq increment by 50;
+            ALTER SEQUENCE event_id_seq increment by 50;
+            ALTER SEQUENCE field_type_id_seq increment by 50;
+            ALTER SEQUENCE field_type_list_item_id_seq increment by 50;
+
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/repository/src/main/resources/db/changelog/db.changelog-rdm-8692.xml
+++ b/repository/src/main/resources/db/changelog/db.changelog-rdm-8692.xml
@@ -13,6 +13,10 @@
             ALTER SEQUENCE event_id_seq increment by 50;
             ALTER SEQUENCE field_type_id_seq increment by 50;
             ALTER SEQUENCE field_type_list_item_id_seq increment by 50;
+            ALTER SEQUENCE display_group_id_seq increment by 50;
+            ALTER SEQUENCE webhook_id_seq increment by 50;
+            ALTER SEQUENCE event_webhook_id_seq increment by 50;
+
 
         </sql>
     </changeSet>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-8962


### Change description ###

A gateway timeout occurs when a definition import takes longer than 30 seconds, which many definitions do. This PR improves performance to ensure imports happen in under 30 seconds.

It fixes several bottlenecks in definition processing and database utilisation; please see individual commits for details. Recommend viewing the diff with ?w=1

Timings, measuring import of divorce definition against a DEMO db backup:

| run | develop (seconds) | PR branch (seconds)  | 
|---|---|---|
|1| 43  | 6.3  | 
|2|  41 | 6.4  |
|3| 40  | 6.2  |

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
