### PR TITLE
RDM-9522 - Use befta-fw release providing callback url substitution

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -50,7 +50,7 @@ env.OAUTH2_CLIENT_ID = "ccd_gateway"
 env.OAUTH2_REDIRECT_URI = "https://www-ccd.aat.platform.hmcts.net/oauth2redirect"
 env.CCD_CASEWORKER_AUTOTEST_EMAIL = "auto.test.cnp@gmail.com"
 env.BEFTA_RESPONSE_HEADER_CHECK_POLICY="JUST_WARN"
-
+env.CCD_STUB_SERVICE_URI_BASE="ccd-test-stubs-service-aat.service.core-compute-aat.internal"
 
 withPipeline(type, product, app) {
     // Vars needed for functional and smoke tests run against AKS

--- a/aat/src/aat/resources/features/F-080/S-080.1.td.json
+++ b/aat/src/aat/resources/features/F-080/S-080.1.td.json
@@ -349,7 +349,7 @@
        ],
 			 "pre_states": [],
 			 "post_state": "CaseCreated",
-			 "callback_url_about_to_start_event": "http://ccd-test-stubs-service-aat.service.core-compute-aat.internal/case_type/fe-functional-test/mid_event_dynamic_list",
+			 "callback_url_about_to_start_event": "http://{{CCD_STUB_SERVICE_URI_BASE}}/case_type/fe-functional-test/mid_event_dynamic_list",
 			 "retries_timeout_about_to_start_event": [],
 			 "callback_url_about_to_submit_event": null,
 			 "retries_timeout_url_about_to_submit_event": [],

--- a/build.gradle
+++ b/build.gradle
@@ -278,7 +278,7 @@ subprojects { subproject ->
         testCompile "io.rest-assured:rest-assured:${restAssuredVersion}"
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-        testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '5.8.0'
+        testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '5.9.0.ACA-60.4'
 
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -278,7 +278,7 @@ subprojects { subproject ->
         testCompile "io.rest-assured:rest-assured:${restAssuredVersion}"
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-        testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '5.9.0.ACA-60.4'
+        testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '5.9.0'
 
     }
 


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RDM-9522

Change description
Use latest version of befta-fw

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[X] No