### PR TITLE
RDM-10386 updated DEFINITION_STORE_DB_MAX_POOL_SIZE to 25

### DIFF
--- a/charts/ccd-definition-store-api/Chart.yaml
+++ b/charts/ccd-definition-store-api/Chart.yaml
@@ -2,7 +2,7 @@ description: Helm chart for the HMCTS CCD Definition Store
 name: ccd-definition-store-api
 apiVersion: v2
 home: https://github.com/hmcts/ccd-definition-store-api
-version: 1.5.2
+version: 1.5.3
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-definition-store-api/values.yaml
+++ b/charts/ccd-definition-store-api/values.yaml
@@ -4,7 +4,7 @@ java:
   applicationPort: 4451
   aadIdentityName: ccd
   autoscaling:
-    enabled: true 
+    enabled: true
     maxReplicas: 4
   keyVaults:
     ccd:
@@ -22,7 +22,7 @@ java:
     DEFINITION_STORE_DB_HOST: ccd-definition-store-api-postgres-db-{{ .Values.global.environment }}.postgres.database.azure.com
     DEFINITION_STORE_DB_USERNAME: ccd@ccd-definition-store-api-postgres-db-{{ .Values.global.environment }}
     DEFINITION_STORE_DB_OPTIONS: "?sslmode=require&gssEncMode=disable"
-    DEFINITION_STORE_DB_MAX_POOL_SIZE: 32
+    DEFINITION_STORE_DB_MAX_POOL_SIZE: 25
 
 
     DEFINITION_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_admin,jui_webapp,pui_webapp


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-10386


### Change description ###
Flaky DefStore pipeline: investigate intermittent max_connections issue on AAT


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
