### PR TITLE
RDM-10797 Set flyway.ignoreMissingMigrations to true.

### DIFF
--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -121,5 +121,6 @@ flyway.noop.strategy=${FLYWAY_NOOP_STRATEGY:false}
 spring.flyway.baseline-on-migrate=true
 spring.flyway.baseline-version=0001
 spring.flyway.out-of-order=true
+spring.flyway.ignoreMissingMigrations=true
 
 case.event.default.publish=${CASE_EVENT_DEFAULT_PUBLISH:false}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-10797


### Change description ###
When changing from develop to master, we have had migrations that are ahead and this was causing the error and preventing the service start. This property disables the check.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
