### PR TITLE
RDM-10705 - Point to pre-release befta-fw version

### DIFF
--- a/aat/build.gradle
+++ b/aat/build.gradle
@@ -47,8 +47,11 @@ task smoke(type: Test) {
         javaexec {
             main = "uk.gov.hmcts.ccd.definitionstore.befta.DefinitionStoreBeftaMain"
             classpath += configurations.cucumberRuntime + sourceSets.aat.runtimeClasspath + sourceSets.main.output + sourceSets.test.output
-            args = ['--plugin', "json:${rootDir}/target/cucumber.json", '--tags', '@Smoke', '--glue',
-                    'uk.gov.hmcts.befta.player', 'src/aat/resources/features']
+            args = ['--threads', '10',
+                    '--plugin', "json:${rootDir}/target/cucumber.json",
+                    '--tags', '@Smoke',
+                    '--glue', 'uk.gov.hmcts.befta.player',
+                    'src/aat/resources/features']
             jvmArgs = [ '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED' ]
         }
     }
@@ -59,6 +62,8 @@ task smoke(type: Test) {
                 delete "${rootDir}/BEFTA Report for Smoke Tests/"
                 new File("${rootDir}/BEFTA Report for Smoke Tests").mkdirs()
                 file("${rootDir}/target/cucumber/cucumber-html-reports").renameTo(file("${rootDir}/BEFTA Report for Smoke Tests"))
+
+                logger.quiet("Smoke test report moved to ---> file://${rootDir}/BEFTA%20Report%20for%20Smoke%20Tests/overview-features.html")
             }
         }
     }
@@ -88,8 +93,11 @@ task functional(type: Test) {
         javaexec {
             main = "uk.gov.hmcts.ccd.definitionstore.befta.DefinitionStoreBeftaMain"
             classpath += configurations.cucumberRuntime + sourceSets.aat.runtimeClasspath + sourceSets.main.output + sourceSets.test.output
-            args = ['--plugin', "json:${rootDir}/target/cucumber.json", '--tags', 'not @Ignore', '--glue',
-                    'uk.gov.hmcts.befta.player', 'src/aat/resources/features']
+            args = ['--threads', '1', // current definition-store tests do not support multiple threads
+                    '--plugin', "json:${rootDir}/target/cucumber.json",
+                    '--tags', 'not @Ignore',
+                    '--glue', 'uk.gov.hmcts.befta.player',
+                    'src/aat/resources/features']
             jvmArgs = [ '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED' ]
         }
     }
@@ -100,6 +108,8 @@ task functional(type: Test) {
                 delete "${rootDir}/BEFTA Report for Functional Tests/"
                 new File("${rootDir}/BEFTA Report for Functional Tests").mkdirs()
                 file("${rootDir}/target/cucumber/cucumber-html-reports").renameTo(file("${rootDir}/BEFTA Report for Functional Tests"))
+
+                logger.quiet("Functional test report moved to ---> file://${rootDir}/BEFTA%20Report%20for%20Functional%20Tests/overview-features.html")
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ subprojects { subproject ->
         testCompile "io.rest-assured:rest-assured:${restAssuredVersion}"
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-        testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.5.3-RDM-10705'
+        testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.5.3'
     }
 
     // from https://github.com/junit-team/junit5/issues/1024

--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ subprojects { subproject ->
         testCompile "io.rest-assured:rest-assured:${restAssuredVersion}"
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-        testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.5.2'
+        testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.5.3-RDM-10705'
     }
 
     // from https://github.com/junit-team/junit5/issues/1024


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-10705](https://tools.hmcts.net/jira/browse/RDM-10705) _"Data-store FTA 403 failures when running against a local ccd-docker environment"_

### Change description ###

Point to yet to be released pre-release version of befta-fw, see hmcts/befta-fw#133.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
