### PR TITLE
RDM-12168 CVE-2021-29425 - bump up dependencies to resolve CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,9 @@ subprojects { subproject ->
         }
         compile "org.bouncycastle:bcprov-jdk15on:1.61", "org.bouncycastle:bcpkix-jdk15on:1.61"
 
+        // CVE-2021-29425
+        compile group: 'commons-io', name: 'commons-io', version: '2.8.0'
+
         // To avoid compiler warnings about @API annotations in JUnit5 code.
         testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
         testCompile "org.postgresql:postgresql:42.2.16"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-12168

### Change description ###

bump up dependencies to resolve CVE-2021-29425

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
