### PR TITLE
CCD-1223: separate beta-fw & ccd-test-defintions 

### DIFF
--- a/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreTestAutomationAdapter.java
+++ b/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreTestAutomationAdapter.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.befta.player.BackEndFunctionalTestScenarioContext;
 
 public class DefinitionStoreTestAutomationAdapter extends DefaultTestAutomationAdapter {
 
-    public static final String DEFAULT_DEFINITIONS_PATH = "uk/gov/hmcts/befta/dse/ccd/definitions/valid";
+    public static final String DEFAULT_DEFINITIONS_PATH = "uk/gov/hmcts/ccd/test_definitions/valid";
 
     private TestDataLoaderToDefinitionStore loader = new TestDataLoaderToDefinitionStore(this, DEFAULT_DEFINITIONS_PATH,
         BeftaMain.getConfig().getTestUrl());

--- a/aat/src/aat/resources/features/F-089/S-089.1.td.json
+++ b/aat/src/aat/resources/features/F-089/S-089.1.td.json
@@ -12,7 +12,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+			 "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-089/S-089.3.td.json
+++ b/aat/src/aat/resources/features/F-089/S-089.3.td.json
@@ -12,7 +12,7 @@
 			"arrayInMap": [
 				{
 					"key": "file",
-					"filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid.xlsx"
+					"filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid.xlsx"
 				}
 			]
 		}

--- a/aat/src/aat/resources/features/F-090/S-090.2.td.json
+++ b/aat/src/aat/resources/features/F-090/S-090.2.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.1.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_Invalid_CaseField.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_Invalid_CaseField.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.2.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_Duplicate_Priority.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_Duplicate_Priority.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.3.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.3.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_No_Default_Post_State.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_No_Default_Post_State.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.4.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.4.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_Missing_Priority.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_Missing_Priority.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.5.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.5.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_Invalid_Condition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_Invalid_Condition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.6.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.6.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_Invalid_Post_State.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_Invalid_Post_State.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.1.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.1.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.2.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_config_retain_hidden_value.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_config_retain_hidden_value.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.3.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.3.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_retain_hidden_no_show_condition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_retain_hidden_no_show_condition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.4.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.4.td.json
@@ -14,7 +14,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_retain_hidden_for_subfields_of_complex_type.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_retain_hidden_for_subfields_of_complex_type.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.5.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.5.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_RetainHiddenValue_CaseEventToComplex_Error2.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_RetainHiddenValue_CaseEventToComplex_Error2.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.6.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.6.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_RetainHiddenValue_CaseEventToComplex_Error1.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_RetainHiddenValue_CaseEventToComplex_Error1.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-094 NoC ChallengeQuestions/S-094.5.td.json
+++ b/aat/src/aat/resources/features/F-094 NoC ChallengeQuestions/S-094.5.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_ChallengeQuestion_DuplicateDisplayOrder.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_ChallengeQuestion_DuplicateDisplayOrder.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-094 NoC ChallengeQuestions/S-094.6.td.json
+++ b/aat/src/aat/resources/features/F-094 NoC ChallengeQuestions/S-094.6.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_ChallengeQuestion_DuplicateQuestionId.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_ChallengeQuestion_DuplicateQuestionId.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-094 NoC ChallengeQuestions/S-094.7.td.json
+++ b/aat/src/aat/resources/features/F-094 NoC ChallengeQuestions/S-094.7.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_ChallengeQuestion_MissingId.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_ChallengeQuestion_MissingId.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.1.td.json
+++ b/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_Invalid_Event_Enabling_Condition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_Invalid_Event_Enabling_Condition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
+++ b/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.10.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.10.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_CaseEventToComplexType_PublishAs_Column.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_CaseEventToComplexType_PublishAs_Column.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.11.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.11.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_Non_Unique_PublishAs_Column.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_Non_Unique_PublishAs_Column.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.2.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_Case_Event_Publish_Column.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_Case_Event_Publish_Column.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.4.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.4.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_CaseEventToFields_Publish_Column.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_CaseEventToFields_Publish_Column.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.5.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.5.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_CaseEventToComplexType_Publish_Column.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_CaseEventToComplexType_Publish_Column.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.6.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.6.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_CaseEvent_No_CaseEventToFields_Yes_Publish_Column.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_CaseEvent_No_CaseEventToFields_Yes_Publish_Column.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.7.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.7.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_CaseEvent_No_CaseEventToComplexType_Yes_Publish_Column.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_CaseEvent_No_CaseEventToComplexType_Yes_Publish_Column.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.8.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.8.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_missing_Publish_Column_CaseEventToField_EventToComplex.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_missing_Publish_Column_CaseEventToField_EventToComplex.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.9.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.9.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_invalid_CaseEventToField_PublishAs_Column.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_invalid_CaseEventToField_PublishAs_Column.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-096/S-096.1.td.json
+++ b/aat/src/aat/resources/features/F-096/S-096.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_Invalid_ChangeOrganisationRequest_Defined_Twice.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_Invalid_ChangeOrganisationRequest_Defined_Twice.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-096/S-096.2.td.json
+++ b/aat/src/aat/resources/features/F-096/S-096.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_Invalid_CaseTypeUserRole_Multiple_Events.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_Invalid_CaseTypeUserRole_Multiple_Events.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.1.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_RoleToAccessProfiles_Invalid_CaseType.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_RoleToAccessProfiles_Invalid_CaseType.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.2.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_RoleToAccessProfiles_Invalid_AccessProfile.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_RoleToAccessProfiles_Invalid_AccessProfile.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.3.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.3.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_RoleToAccessProfiles_Invalid_ReadOnly.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_RoleToAccessProfiles_Invalid_ReadOnly.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.4.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.4.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_RoleToAccessProfiles_Invalid_Disabled.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_RoleToAccessProfiles_Invalid_Disabled.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/BEFTA_Master_Definition.xlsx"
+			 "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/excel/CCD_BEFTA_JURISDICTION2.xlsx"
+			 "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/CCD_BEFTA_JURISDICTION2.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.3.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.3.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "filePath": "uk/gov/hmcts/befta/dse/ccd/definitions/invalid/BEFTA_Master_Definition_Invalid_AccessProfile_Column.xlsx"
+			 "filePath": "uk/gov/hmcts/ccd/test_definitions/invalid/BEFTA_Master_Definition_Invalid_AccessProfile_Column.xlsx"
 			}
 		]
 	 }

--- a/build.gradle
+++ b/build.gradle
@@ -260,7 +260,7 @@ subprojects { subproject ->
         testCompile "io.rest-assured:rest-assured:${restAssuredVersion}"
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0.4'
+        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0-ccd-1223.1'
     }
 
     // from https://github.com/junit-team/junit5/issues/1024'

--- a/build.gradle
+++ b/build.gradle
@@ -260,7 +260,7 @@ subprojects { subproject ->
         testCompile "io.rest-assured:rest-assured:${restAssuredVersion}"
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-        testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '7.0.0'
+        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0.4'
     }
 
     // from https://github.com/junit-team/junit5/issues/1024'

--- a/build.gradle
+++ b/build.gradle
@@ -260,7 +260,7 @@ subprojects { subproject ->
         testCompile "io.rest-assured:rest-assured:${restAssuredVersion}"
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0-ccd-1223.1'
+        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0'
     }
 
     // from https://github.com/junit-team/junit5/issues/1024'


### PR DESCRIPTION
### JIRA link (if applicable) ###

[CCD-1223](https://tools.hmcts.net/jira/browse/CCD-1223) _"Split Generic Framework Core from CCD Data & Logic"_

### Change description ###

Use befta fw and ccd definitions from separate artefacts.

Uses new hmcts/ccd-test-definitions#1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
