### PR TITLE
CCD-1322: Updated CVE suppression dates

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,7 +2,7 @@
 <suppressions
 	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-	<suppress until="2021-06-25">
+	<suppress until="2021-07-25">
 		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
 			(any version), see https://pivotal.io/security/cve-2018-1258
 			False
@@ -11,7 +11,7 @@
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-	<suppress until="2021-06-25">
+	<suppress until="2021-07-25">
 		<notes>These CVE's are coming from Dhowden tag library and it impacts
 			only MP3/MP4/OGG/FLAC metadata parsing
 			library. Also it is declared as
@@ -27,7 +27,7 @@
 	<!-- !!!!!!! This suppression should not be removed until the elastic search
 		client is updated to 7. Before updating the elastic client make sure that
 		the server has been updated to 7 !!!!! -->
-	<suppress until="2021-06-25">
+	<suppress until="2021-07-25">
 		<notes><![CDATA[
       		  Jar: org.elasticsearch/elasticsearch@6.4.3
       		  Analysis: These CVEs expected to be fixed as part of RDM-9054
@@ -42,7 +42,7 @@
 
 	</suppress>
 
-	<suppress until="2021-06-25">
+	<suppress until="2021-07-25">
 		<notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk
 			#2866
 			https://github.com/jeremylong/DependencyCheck/issues/2866


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1322 (https://tools.hmcts.net/jira/browse/CCD-1322)


### Change description ###
Updated CVE suppression dates in dependency-check-suppressions.xml to 25/07/2021


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
