### PR TITLE
CCD-1330: Updated CVE suppression dates to 25/08/2021

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -7,6 +7,7 @@
 			(any version), see https://pivotal.io/security/cve-2018-1258
 			False
 			positive confirmed.
+			Last control version: 5.5.1
 		</notes>
 		<cve>CVE-2018-1258</cve>
 	</suppress>
@@ -17,6 +18,7 @@
 			library. Also it is declared as
 			false positive in
 			https://github.com/jeremylong/DependencyCheck/issues/3043
+			Last control version:  1.5
 		</notes>
 		<cve>CVE-2020-29242</cve>
 		<cve>CVE-2020-29243</cve>
@@ -28,6 +30,7 @@
 		<notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk
 			#2866
 			https://github.com/jeremylong/DependencyCheck/issues/2866
+			Last control version: 9.10.1
 		</notes>
 		<cve>CVE-2007-1651</cve>
 		<cve>CVE-2007-1652</cve>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,7 +2,7 @@
 <suppressions
 	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-	<suppress until="2021-07-25">
+	<suppress until="2021-08-25">
 		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
 			(any version), see https://pivotal.io/security/cve-2018-1258
 			False
@@ -11,7 +11,7 @@
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-	<suppress until="2021-07-25">
+	<suppress until="2021-08-25">
 		<notes>These CVE's are coming from Dhowden tag library and it impacts
 			only MP3/MP4/OGG/FLAC metadata parsing
 			library. Also it is declared as
@@ -24,7 +24,7 @@
 		<cve>CVE-2020-29245</cve>
 	</suppress>
 
-	<suppress until="2021-07-25">
+	<suppress until="2021-08-25">
 		<notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk
 			#2866
 			https://github.com/jeremylong/DependencyCheck/issues/2866


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1330 (https://tools.hmcts.net/jira/browse/CCD-1330)
https://tools.hmcts.net/jira/browse/CCD-1669
https://tools.hmcts.net/jira/browse/CCD-1670
https://tools.hmcts.net/jira/browse/CCD-1671
https://tools.hmcts.net/jira/browse/CCD-1672
https://tools.hmcts.net/jira/browse/CCD-1673
https://tools.hmcts.net/jira/browse/CCD-1674
https://tools.hmcts.net/jira/browse/CCD-1675

### Change description ###
Updated CVE suppression dates to 25/08/2021


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
