### PR TITLE
Override transitive dependency commons-compress

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,8 @@ allprojects {
         compile "com.fasterxml.jackson.core:jackson-databind:2.11.1"
         compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
         compile "org.hibernate:hibernate-core:${hibernateVersion}"
+        // Overriding transitive dependency commons-compress due to CVE failures
+        compile "org.apache.commons:commons-compress:1.21"
         testCompile "io.rest-assured:xml-path:${restAssuredVersion}"
         testCompile "io.rest-assured:json-path:${restAssuredVersion}"
         testCompile "org.codehaus.groovy:groovy:${groovyVersion}"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -36,15 +36,4 @@
 		<cve>CVE-2007-1652</cve>
 	</suppress>
 
-	<suppress until="2021-08-25">
-		<notes> CVE's raising flaws in apache-commons-compress highlighting
-			potential denial of service attacks when using compressed files.
-			To be fixed in Jira tickets CCD-1696, CCD-1697, CCD-1698 and CCD-1699
-		</notes>
-		<cve>CVE-2021-35515</cve>
-		<cve>CVE-2021-35516</cve>
-		<cve>CVE-2021-35517</cve>
-		<cve>CVE-2021-36090</cve>
-	</suppress>
-
 </suppressions>


### PR DESCRIPTION
### [CCD-1696](https://tools.hmcts.net/jira/browse/CCD-1696) ###
### [CCD-1697](https://tools.hmcts.net/jira/browse/CCD-1697) ###
### [CCD-1698](https://tools.hmcts.net/jira/browse/CCD-1698) ###
### [CCD-1699](https://tools.hmcts.net/jira/browse/CCD-1699) ###


### Change description ###
Override transitive dependency on Apache Commons Compress due to CVE-2021-35515, CVE-2021-35516, CVE-2021-35517 & CVE-2021-36090


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
