### PR TITLE
RDM-12754 Fix: Definition Store FTAs import raw BEFTA definition files with invalid callbacks

### DIFF
--- a/aat/.gitignore
+++ b/aat/.gitignore
@@ -1,1 +1,2 @@
 /bin/
+/definition_files/

--- a/aat/.gitignore
+++ b/aat/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /definition_files/
+_temp_*.xlsx

--- a/aat/build.gradle
+++ b/aat/build.gradle
@@ -125,6 +125,17 @@ task functional(type: Test) {
 
     outputs.upToDateWhen { false }
 }
+
+// allows execution of individual functional tests from within IntelliJ wihout full execution of BEFTA
+task functionalNoCucumberReport(type: Test) {
+    description = 'Executes functional tests against the CCD Definition Store Instance just deployed'
+    setTestClassesDirs(sourceSets.aat.output.classesDirs)
+    setClasspath(sourceSets.aat.runtimeClasspath)
+    useJUnitPlatform()
+
+    dependsOn aatClasses
+}
+
 cucumberReports {
     outputDir = file("${rootDir}/target/cucumber")
     reports = files("${rootDir}/target/cucumber.json")

--- a/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreBeftaMain.java
+++ b/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreBeftaMain.java
@@ -5,7 +5,11 @@ import uk.gov.hmcts.befta.BeftaMain;
 public class DefinitionStoreBeftaMain extends BeftaMain {
 
     public static void main(String[] args) {
-        BeftaMain.main(args, new DefinitionStoreTestAutomationAdapter());
+
+        var taAdapter = new DefinitionStoreTestAutomationAdapter();
+        taAdapter.initialiseTestDataLoader();
+
+        BeftaMain.main(args, taAdapter);
     }
 
 }

--- a/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreBeftaRunner.java
+++ b/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreBeftaRunner.java
@@ -7,11 +7,13 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import uk.gov.hmcts.befta.BeftaMain;
 
-
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = "json:target/cucumber.json",
-    glue = "uk.gov.hmcts.befta.player",
-    features = {"classpath:features"})
+@CucumberOptions(
+    plugin = { "json:target/cucumber.json", "pretty" },
+    glue = { "uk.gov.hmcts.befta.player" },
+    features = { "classpath:features" },
+    tags = { "not @Ignore" }
+)
 public class DefinitionStoreBeftaRunner {
 
     private DefinitionStoreBeftaRunner() {
@@ -21,7 +23,10 @@ public class DefinitionStoreBeftaRunner {
 
     @BeforeClass
     public static void setUp() {
-        BeftaMain.setUp(new DefinitionStoreTestAutomationAdapter());
+        var taAdapter = new DefinitionStoreTestAutomationAdapter();
+        taAdapter.initialiseTestDataLoader();
+
+        BeftaMain.setUp(taAdapter);
     }
 
     @AfterClass

--- a/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreTestAutomationAdapter.java
+++ b/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreTestAutomationAdapter.java
@@ -1,20 +1,16 @@
 package uk.gov.hmcts.ccd.definitionstore.befta;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.befta.BeftaTestDataLoader;
 import uk.gov.hmcts.befta.DefaultTestAutomationAdapter;
 import uk.gov.hmcts.befta.dse.ccd.DataLoaderToDefinitionStore;
 import uk.gov.hmcts.befta.player.BackEndFunctionalTestScenarioContext;
+import uk.gov.hmcts.befta.util.BeftaUtils;
 
 import static uk.gov.hmcts.befta.dse.ccd.DataLoaderToDefinitionStore.VALID_CCD_TEST_DEFINITIONS_PATH;
 
-
 public class DefinitionStoreTestAutomationAdapter extends DefaultTestAutomationAdapter {
 
-    private static final Logger log = LoggerFactory.getLogger(DefinitionStoreTestAutomationAdapter.class);
-
-    public static final String TEMPORARY_DEFINITION_FOLDER = "build/tmp/definition_files_copy";
+    public static final String TEMPORARY_DEFINITION_FOLDER = BeftaUtils.getBuildPath() + "/tmp/definition_files_copy";
 
     private DataLoaderToDefinitionStore testDataLoader;
 
@@ -36,12 +32,12 @@ public class DefinitionStoreTestAutomationAdapter extends DefaultTestAutomationA
         if (testDataLoader == null) {
             testDataLoader = new DataLoaderToDefinitionStore(this, VALID_CCD_TEST_DEFINITIONS_PATH);
 
-            log.info(
-                "Copy valid def files generated from a JSON template to a temporary location for use in FTAs: '{}'",
+            BeftaUtils.defaultLog(String.format(
+                "Copy valid def files generated from a JSON template to a temporary location for use in FTAs: '%s'",
                 TEMPORARY_DEFINITION_FOLDER
-            );
+            ));
             testDataLoader.getAllDefinitionFilesToLoadAt(VALID_CCD_TEST_DEFINITIONS_PATH, TEMPORARY_DEFINITION_FOLDER);
-            log.info("Copy complete.\n");
+            BeftaUtils.defaultLog("Copy complete.\n");
         }
     }
 

--- a/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreTestAutomationAdapter.java
+++ b/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreTestAutomationAdapter.java
@@ -1,25 +1,48 @@
 package uk.gov.hmcts.ccd.definitionstore.befta;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.befta.BeftaTestDataLoader;
 import uk.gov.hmcts.befta.DefaultTestAutomationAdapter;
 import uk.gov.hmcts.befta.dse.ccd.DataLoaderToDefinitionStore;
 import uk.gov.hmcts.befta.player.BackEndFunctionalTestScenarioContext;
 
+import static uk.gov.hmcts.befta.dse.ccd.DataLoaderToDefinitionStore.VALID_CCD_TEST_DEFINITIONS_PATH;
+
+
 public class DefinitionStoreTestAutomationAdapter extends DefaultTestAutomationAdapter {
 
-    public static final String DEFAULT_DEFINITIONS_PATH = "uk/gov/hmcts/ccd/test_definitions/valid";
+    private static final Logger log = LoggerFactory.getLogger(DefinitionStoreTestAutomationAdapter.class);
+
+    public static final String TEMPORARY_DEFINITION_FOLDER = "build/tmp/definition_files_copy";
+
+    private DataLoaderToDefinitionStore testDataLoader;
 
     @Override
     protected BeftaTestDataLoader buildTestDataLoader() {
-        return new DataLoaderToDefinitionStore(this,
-            DataLoaderToDefinitionStore.VALID_CCD_TEST_DEFINITIONS_PATH);
+        initialiseTestDataLoader();
+        return this.testDataLoader;
     }
 
     @Override
-    public Object calculateCustomValue(BackEndFunctionalTestScenarioContext scenarioContext, Object key) {
+    public synchronized Object calculateCustomValue(BackEndFunctionalTestScenarioContext scenarioContext, Object key) {
         if (key.toString().startsWith("no_dynamic_injection_")) {
             return key.toString().replace("no_dynamic_injection_","");
         }
         return super.calculateCustomValue(scenarioContext, key);
     }
+
+    public void initialiseTestDataLoader() {
+        if (testDataLoader == null) {
+            testDataLoader = new DataLoaderToDefinitionStore(this, VALID_CCD_TEST_DEFINITIONS_PATH);
+
+            log.info(
+                "Copy valid def files generated from a JSON template to a temporary location for use in FTAs: '{}'",
+                TEMPORARY_DEFINITION_FOLDER
+            );
+            testDataLoader.getAllDefinitionFilesToLoadAt(VALID_CCD_TEST_DEFINITIONS_PATH, TEMPORARY_DEFINITION_FOLDER);
+            log.info("Copy complete.\n");
+        }
+    }
+
 }

--- a/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreTestAutomationAdapter.java
+++ b/aat/src/aat/java/uk/gov/hmcts/ccd/definitionstore/befta/DefinitionStoreTestAutomationAdapter.java
@@ -10,7 +10,7 @@ import static uk.gov.hmcts.befta.dse.ccd.DataLoaderToDefinitionStore.VALID_CCD_T
 
 public class DefinitionStoreTestAutomationAdapter extends DefaultTestAutomationAdapter {
 
-    public static final String TEMPORARY_DEFINITION_FOLDER = BeftaUtils.getBuildPath() + "/tmp/definition_files_copy";
+    public static final String TEMPORARY_DEFINITION_FOLDER = "build/tmp/definition_files_copy";
 
     private DataLoaderToDefinitionStore testDataLoader;
 

--- a/aat/src/aat/resources/features/F-089/S-089.1.td.json
+++ b/aat/src/aat/resources/features/F-089/S-089.1.td.json
@@ -12,7 +12,7 @@
 		"arrayInMap": [
 			{
 				"key": "file",
-				"localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+				"localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-089/S-089.1.td.json
+++ b/aat/src/aat/resources/features/F-089/S-089.1.td.json
@@ -11,8 +11,8 @@
 	 "body": {
 		"arrayInMap": [
 			{
-			 "key": "file",
-			 "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+				"key": "file",
+				"localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-089/S-089.1.td.json
+++ b/aat/src/aat/resources/features/F-089/S-089.1.td.json
@@ -12,7 +12,7 @@
 		"arrayInMap": [
 			{
 				"key": "file",
-				"localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+				"localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-089/S-089.1.td.json
+++ b/aat/src/aat/resources/features/F-089/S-089.1.td.json
@@ -12,7 +12,7 @@
 		"arrayInMap": [
 			{
 				"key": "file",
-				"localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+				"localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-090/S-090.2.td.json
+++ b/aat/src/aat/resources/features/F-090/S-090.2.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-090/S-090.2.td.json
+++ b/aat/src/aat/resources/features/F-090/S-090.2.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-090/S-090.2.td.json
+++ b/aat/src/aat/resources/features/F-090/S-090.2.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-090/S-090.2.td.json
+++ b/aat/src/aat/resources/features/F-090/S-090.2.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
+++ b/aat/src/aat/resources/features/F-092 Conditional Event Post State/S-092.7.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.1.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.1.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.1.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.1.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.1.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.1.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-093/S-600.1.td.json
+++ b/aat/src/aat/resources/features/F-093/S-600.1.td.json
@@ -10,7 +10,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
+++ b/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
+++ b/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
+++ b/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
+++ b/aat/src/aat/resources/features/F-095 Event Enabling Condition/S-095.2.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.12.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
+++ b/aat/src/aat/resources/features/F-095 Publish Flag in Case Event/S-095.3.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.5.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+			 "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+			 "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "localFilePath": "$buildPath/tmp/definition_files_copy/BEFTA_Master.xlsx"
+			 "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.1.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "localFilePath": "./build/tmp/definition_files_copy/BEFTA_Master.xlsx"
+			 "localFilePath": "build/tmp/definition_files_copy/BEFTA_Master.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "localFilePath": "./build/tmp/definition_files_copy/CCD_BEFTA_JURISDICTION2.xlsx"
+			 "localFilePath": "build/tmp/definition_files_copy/CCD_BEFTA_JURISDICTION2.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/CCD_BEFTA_JURISDICTION2.xlsx"
+			 "localFilePath": "./build/tmp/definition_files_copy/CCD_BEFTA_JURISDICTION2.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "localFilePath": "build/tmp/definition_files_copy/CCD_BEFTA_JURISDICTION2.xlsx"
+			 "localFilePath": "$buildPath/tmp/definition_files_copy/CCD_BEFTA_JURISDICTION2.xlsx"
 			}
 		]
 	 }

--- a/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
+++ b/aat/src/aat/resources/features/F-098 rename of UserRole to AccessProfile/S-098.2.td.json
@@ -13,7 +13,7 @@
 		"arrayInMap": [
 			{
 			 "key": "file",
-			 "localFilePath": "$buildPath/tmp/definition_files_copy/CCD_BEFTA_JURISDICTION2.xlsx"
+			 "localFilePath": "build/tmp/definition_files_copy/CCD_BEFTA_JURISDICTION2.xlsx"
 			}
 		]
 	 }

--- a/build.gradle
+++ b/build.gradle
@@ -271,7 +271,7 @@ subprojects { subproject ->
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
         testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0'
-        testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.3.2.RDM-12754.2'
+        testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.3.2.RDM-12754.3'
         // https://mvnrepository.com/artifact/junit/junit
         compile group: 'junit', name: 'junit', version: '4.13.1'
         testCompile 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -271,7 +271,7 @@ subprojects { subproject ->
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
         testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0'
-        testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.3.2.RDM-12754.1'
+        testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.3.2.RDM-12754.2'
         // https://mvnrepository.com/artifact/junit/junit
         compile group: 'junit', name: 'junit', version: '4.13.1'
         testCompile 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -271,7 +271,7 @@ subprojects { subproject ->
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
         testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0'
-        testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.3.0'
+        testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.3.2.RDM-12754.1'
         // https://mvnrepository.com/artifact/junit/junit
         compile group: 'junit', name: 'junit', version: '4.13.1'
         testCompile 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.4.0'


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RDM-12754](https://tools.hmcts.net/jira/browse/RDM-12754) _"Fix: Definition Store FTAs import raw BEFTA definition files with invalid callbacks"_

### Change description ###

For happy path import tests use the generated definition files so the callback URLs are valid and correct for the given environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
