### PR TITLE
RDM-12800 -  use the new local path to the generated copy of definition file

### DIFF
--- a/aat/src/aat/resources/features/F-099 SearchParty (GlobalSearch)/S-099.1.td.json
+++ b/aat/src/aat/resources/features/F-099 SearchParty (GlobalSearch)/S-099.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }

--- a/aat/src/aat/resources/features/F-100 SearchCriteria (GlobalSearch)/S-100.1.td.json
+++ b/aat/src/aat/resources/features/F-100 SearchCriteria (GlobalSearch)/S-100.1.td.json
@@ -11,7 +11,7 @@
       "arrayInMap": [
         {
           "key": "file",
-          "filePath": "uk/gov/hmcts/ccd/test_definitions/excel/BEFTA_Master_Definition.xlsx"
+          "localFilePath": "build/tmp/definition_files_copy/BEFTA_MASTER.xlsx"
         }
       ]
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-12800

### Change description ###

Positive response functional tests that import valid definition files from ccd-test-definitions should use the new local path to the generated copy rather than load direct from the usual resource file location:  i.e. use the generated environment specific excel file rather than the raw excel file from ccd-test-definitions which contains the templated callback URLs which are invalid when not processed by BEFTA-FW.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
