### PR TITLE
RDM-12686 adjust GlobalSearch index mappings

### DIFF
--- a/elastic-search-support/src/main/resources/globalSearchCasesMapping.json
+++ b/elastic-search-support/src/main/resources/globalSearchCasesMapping.json
@@ -1,5 +1,13 @@
 {
   "properties": {
+    "created_date": {
+      "type": "date",
+      "ignore_malformed": true
+    },
+    "last_modified": {
+      "type": "date",
+      "ignore_malformed": true
+    },
     "reference": {
       "type": "text",
       "fields": {
@@ -49,16 +57,8 @@
       "search_analyzer": "alphanumeric_string_analyzer"
     },
     "security_classification": {
-      "type": "text",
-      "fields": {
-        "keyword": {
-          "type": "keyword",
-          "ignore_above": 256,
-          "normalizer": "lowercase_normalizer"
-        }
-      },
-      "analyzer": "standard",
-      "search_analyzer": "alphanumeric_string_analyzer"
+      "type": "keyword",
+      "normalizer": "lowercase_normalizer"
     },
     "data": {
       "type": "object",
@@ -215,264 +215,6 @@
                   "search_analyzer": "alphanumeric_string_analyzer"
                 },
                 "label": {
-                  "type": "text",
-                  "fields": {
-                    "keyword": {
-                      "type": "keyword",
-                      "ignore_above": 256,
-                      "normalizer": "lowercase_normalizer"
-                    }
-                  },
-                  "analyzer": "standard",
-                  "search_analyzer": "alphanumeric_string_analyzer"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "data_classification": {
-      "type": "object",
-      "properties": {
-        "SearchCriteria": {
-          "type": "object",
-          "properties": {
-            "value": {
-              "type": "object",
-              "properties": {
-                "OtherCaseReferences": {
-                  "properties": {
-                    "value": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "enabled": false
-                        },
-                        "value": {
-                          "type": "text",
-                          "fields": {
-                            "keyword": {
-                              "type": "keyword",
-                              "ignore_above": 256,
-                              "normalizer": "lowercase_normalizer"
-                            }
-                          },
-                          "analyzer": "standard",
-                          "search_analyzer": "alphanumeric_string_analyzer"
-                        }
-                      }
-                    },
-                    "classification": {
-                      "type": "text",
-                      "fields": {
-                        "keyword": {
-                          "type": "keyword",
-                          "ignore_above": 256,
-                          "normalizer": "lowercase_normalizer"
-                        }
-                      },
-                      "analyzer": "standard",
-                      "search_analyzer": "alphanumeric_string_analyzer"
-                    }
-                  }
-                },
-                "SearchParties": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "enabled": false
-                        },
-                        "value": {
-                          "type": "nested",
-                          "properties": {
-                            "Name": {
-                              "type": "text",
-                              "fields": {
-                                "keyword": {
-                                  "type": "keyword",
-                                  "ignore_above": 256,
-                                  "normalizer": "lowercase_normalizer"
-                                }
-                              },
-                              "analyzer": "standard",
-                              "search_analyzer": "alphanumeric_string_analyzer"
-                            },
-                            "EmailAddress": {
-                              "type": "text",
-                              "fields": {
-                                "keyword": {
-                                  "type": "keyword",
-                                  "ignore_above": 256,
-                                  "normalizer": "lowercase_normalizer"
-                                }
-                              },
-                              "analyzer": "standard",
-                              "search_analyzer": "alphanumeric_string_analyzer"
-                            },
-                            "AddressLine1": {
-                              "type": "text",
-                              "fields": {
-                                "keyword": {
-                                  "type": "keyword",
-                                  "ignore_above": 256,
-                                  "normalizer": "lowercase_normalizer"
-                                }
-                              },
-                              "analyzer": "standard",
-                              "search_analyzer": "alphanumeric_string_analyzer"
-                            },
-                            "PostCode": {
-                              "type": "text",
-                              "fields": {
-                                "keyword": {
-                                  "type": "keyword",
-                                  "ignore_above": 256,
-                                  "normalizer": "lowercase_normalizer"
-                                }
-                              },
-                              "analyzer": "standard",
-                              "search_analyzer": "alphanumeric_string_analyzer"
-                            },
-                            "DateOfBirth": {
-                              "type": "date",
-                              "ignore_malformed": true
-                            },
-                            "DateOfDeath": {
-                              "type": "date",
-                              "ignore_malformed": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "classification": {
-                      "type": "text",
-                      "fields": {
-                        "keyword": {
-                          "type": "keyword",
-                          "ignore_above": 256,
-                          "normalizer": "lowercase_normalizer"
-                        }
-                      },
-                      "analyzer": "standard",
-                      "search_analyzer": "alphanumeric_string_analyzer"
-                    }
-                  }
-                }
-              }
-            },
-            "classification": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256,
-                  "normalizer": "lowercase_normalizer"
-                }
-              },
-              "analyzer": "standard",
-              "search_analyzer": "alphanumeric_string_analyzer"
-            }
-          }
-        },
-        "caseManagementLocation": {
-          "type": "object",
-          "properties": {
-            "value": {
-              "type": "object",
-              "properties": {
-                "region": {
-                  "type": "text",
-                  "fields": {
-                    "keyword": {
-                      "type": "keyword",
-                      "ignore_above": 256,
-                      "normalizer": "lowercase_normalizer"
-                    }
-                  },
-                  "analyzer": "standard",
-                  "search_analyzer": "alphanumeric_string_analyzer"
-                },
-                "baseLocation": {
-                  "type": "text",
-                  "fields": {
-                    "keyword": {
-                      "type": "keyword",
-                      "ignore_above": 256,
-                      "normalizer": "lowercase_normalizer"
-                    }
-                  },
-                  "analyzer": "standard",
-                  "search_analyzer": "alphanumeric_string_analyzer"
-                }
-              }
-            },
-            "classification": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256,
-                  "normalizer": "lowercase_normalizer"
-                }
-              },
-              "analyzer": "standard",
-              "search_analyzer": "alphanumeric_string_analyzer"
-            }
-          }
-        },
-        "caseNameHmctsInternal": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256,
-              "normalizer": "lowercase_normalizer"
-            }
-          },
-          "analyzer": "standard",
-          "search_analyzer": "alphanumeric_string_analyzer"
-        },
-        "caseManagementCategory": {
-          "type": "object",
-          "properties": {
-            "value": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "object",
-                  "properties": {
-                    "code": {
-                      "type": "text",
-                      "fields": {
-                        "keyword": {
-                          "type": "keyword",
-                          "ignore_above": 256,
-                          "normalizer": "lowercase_normalizer"
-                        }
-                      },
-                      "analyzer": "standard",
-                      "search_analyzer": "alphanumeric_string_analyzer"
-                    },
-                    "label": {
-                      "type": "text",
-                      "fields": {
-                        "keyword": {
-                          "type": "keyword",
-                          "ignore_above": 256,
-                          "normalizer": "lowercase_normalizer"
-                        }
-                      },
-                      "analyzer": "standard",
-                      "search_analyzer": "alphanumeric_string_analyzer"
-                    }
-                  }
-                },
-                "classification": {
                   "type": "text",
                   "fields": {
                     "keyword": {


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-12686](https://tools.hmcts.net/jira/browse/RDM-12686) _"Establish the new Global Search endpoint"_

### Change description ###

Adjust `globalSearchCasesMapping.json`:
 * `created_date` required for default sort order for GlobalSearch.
 * `security_classification` adjusted to match default for case indexes
    for use by ElasticsearchSecurityClassificationFilter
 * removed unused `data_classification` from index

**NB**: this PR points to the branch used by #1077.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
