### PR TITLE
CCD-2113: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
     reformLogging= '5.1.1-BETA'
     restAssuredVersion = '4.3.0!!'
     groovyVersion = '3.0.2!!'
-    tomcatVersion = '9.0.50!!'
+    tomcatVersion = '9.0.54!!'
     hibernateVersion = '5.4.24.Final!!'
     limits = [
             'instruction': 99,

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -52,10 +52,4 @@
 		<cve>CVE-2021-22147</cve>
 	</suppress>
 
-	<suppress until="2021-11-25">
-		<notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-		<cve>CVE-2021-42340</cve>
-
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2113 (https://tools.hmcts.net/jira/browse/CCD-2113)


### Change description ###
- Updated build.gradle. Set value of tomcatVersion property to 9.0.54 to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from dependency-check-suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
