### PR TITLE
CCD-2138: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext['snakeyaml.version'] = '1.26'
 ext['postgresql.version'] = '42.2.16'
 //overriding log4j2 default version 2.7 because of vulnerability issues
 ext['log4j2.version'] = '2.13.2'
-ext['spring-framework.version'] = '5.3.7'
+ext['spring-framework.version'] = '5.3.12'
 
 // end
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -52,9 +52,4 @@
 		<cve>CVE-2021-22147</cve>
 	</suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Temp suppression to unblock pipeline.</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
-
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions
-		xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
 	<suppress>
 		<notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2138 (https://tools.hmcts.net/jira/browse/CCD-2138)


### Change description ###
- Updated build.gradle.  Set value of override of spring-framework.version property to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from dependency-check-suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
