### PR TITLE
CCD-2132: Remove suppression of CVE-2021-22147

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -46,9 +46,4 @@
 		<cve>CVE-2007-1652</cve>
 	</suppress>
 
-	<!-- Temporary suppression. Remove in the fix PR. -->
-	<suppress>
-		<cve>CVE-2021-22147</cve>
-	</suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2132 (https://tools.hmcts.net/jira/browse/CCD-2132)


### Change description ###
- Removed temporary suppression of CVE-2021-22147 from dependency-check-suppressions.xml as CVE does not show up in output from gradle dependency check.  This may be because it only affects versions 7.11.0 to 7.13.4 (see https://discuss.elastic.co/t/elastic-stack-7-14-0-security-update/280344) rather than all versions prior to 7.14.0 (as reported at https://nvd.nist.gov/vuln/detail/CVE-2021-22147).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
