### PR TITLE
CCD-2351: Update log4j version to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ ext['jackson.version'] = '2.10.3'
 ext['snakeyaml.version'] = '1.26'
 ext['postgresql.version'] = '42.2.16'
 //overriding log4j2 default version 2.7 because of vulnerability issues
-ext['log4j2.version'] = '2.15.0'
+ext['log4j2.version'] = '2.16.0'
 ext['spring-framework.version'] = '5.3.12'
 
 // end


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2351 (https://tools.hmcts.net/jira/browse/CCD-2351)


### Change description ###
Update log4j version to 2.16.0.  This release contains further mitigations for CVE-2021-44228 and also addresses CVE-2021-45046.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
