### PR TITLE
Rdm 13013

### DIFF
--- a/elastic-search-support/src/main/resources/application.yml
+++ b/elastic-search-support/src/main/resources/application.yml
@@ -91,6 +91,7 @@ elasticsearch:
     created_date: ${elasticsearch.elasticMappings.defaultDate}
     last_modified: ${elasticsearch.elasticMappings.defaultDate}
     security_classification: ${elasticsearch.elasticMappings.defaultKeyword}
+    case_access_category:   ${elasticsearch.elasticMappings.defaultText}
     case_type_id: ${elasticsearch.elasticMappings.defaultText}
     last_state_modified_date: ${elasticsearch.elasticMappings.defaultDate}
 #    '[@timestamp]' brackets added for getting along with spring boot 2

--- a/elastic-search-support/src/main/resources/application.yml
+++ b/elastic-search-support/src/main/resources/application.yml
@@ -91,7 +91,6 @@ elasticsearch:
     created_date: ${elasticsearch.elasticMappings.defaultDate}
     last_modified: ${elasticsearch.elasticMappings.defaultDate}
     security_classification: ${elasticsearch.elasticMappings.defaultKeyword}
-    case_access_category:   ${elasticsearch.elasticMappings.defaultText}
     case_type_id: ${elasticsearch.elasticMappings.defaultText}
     last_state_modified_date: ${elasticsearch.elasticMappings.defaultDate}
 #    '[@timestamp]' brackets added for getting along with spring boot 2

--- a/elastic-search-support/src/main/resources/globalSearchCasesMapping.json
+++ b/elastic-search-support/src/main/resources/globalSearchCasesMapping.json
@@ -56,6 +56,18 @@
       "analyzer": "standard",
       "search_analyzer": "alphanumeric_string_analyzer"
     },
+    "case_access_category": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256,
+          "normalizer": "lowercase_normalizer"
+        }
+      },
+      "analyzer": "standard",
+      "search_analyzer": "alphanumeric_string_analyzer"
+    },
     "security_classification": {
       "type": "keyword",
       "normalizer": "lowercase_normalizer"

--- a/elastic-search-support/src/main/resources/globalSearchCasesMapping.json
+++ b/elastic-search-support/src/main/resources/globalSearchCasesMapping.json
@@ -56,18 +56,6 @@
       "analyzer": "standard",
       "search_analyzer": "alphanumeric_string_analyzer"
     },
-    "case_access_category": {
-      "type": "text",
-      "fields": {
-        "keyword": {
-          "type": "keyword",
-          "ignore_above": 256,
-          "normalizer": "lowercase_normalizer"
-        }
-      },
-      "analyzer": "standard",
-      "search_analyzer": "alphanumeric_string_analyzer"
-    },
     "security_classification": {
       "type": "keyword",
       "normalizer": "lowercase_normalizer"
@@ -75,6 +63,18 @@
     "data": {
       "type": "object",
       "properties": {
+        "CaseAccessCategory": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256,
+              "normalizer": "lowercase_normalizer"
+            }
+          },
+          "analyzer": "standard",
+          "search_analyzer": "alphanumeric_string_analyzer"
+        },
         "SearchCriteria": {
           "type": "object",
           "properties": {


### PR DESCRIPTION

     RDM-13013: Include CaseAccessCategory in the standard search fields for the new ES Global Search Index
           [RDM-13013] (https://tools.hmcts.net/jira/browse/RDM-13013).

