### PR TITLE
[DO NOT MERGE] RDM-13103 temporary ELASTIC_SEARCH_HOST override

### DIFF
--- a/charts/ccd-definition-store-api/values.preview.template.yaml
+++ b/charts/ccd-definition-store-api/values.preview.template.yaml
@@ -22,7 +22,8 @@ java:
     # enable whenever required and provide host url to match with corresponding data-store-api
     ELASTIC_SEARCH_ENABLED: true
 
-    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
+    # TODO: remove TEMPORARY OVERRIDE FOR RDM-13103, reinstate: ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
+    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1809-es-master
 
     USER_PROFILE_HOST: http://ccd-user-profile-api-pr-399.service.core-compute-preview.internal
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-13103](https://tools.hmcts.net/jira/browse/RDM-13103) _"Swap from data-store preview reliance on logstash images to pure charts config"_

### Change description ###

Temporary override of `ELASTIC_SEARCH_HOST` to point to different PR.  Needed to test RDM-1303 changes in hmcts/ccd-data-store-api#1809.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
