### PR TITLE
[DO NOT MERGE] Dummy PR for testing GS elastic search FTAs in RDM-13121

### DIFF
--- a/charts/ccd-definition-store-api/values.preview.template.yaml
+++ b/charts/ccd-definition-store-api/values.preview.template.yaml
@@ -23,7 +23,7 @@ java:
     ELASTIC_SEARCH_ENABLED: true
 
     # TODO: remove TEMPORARY OVERRIDE FOR GlobalSearch R2, reinstate: ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
-    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1861-es-master
+    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1864-es-master
 
     USER_PROFILE_HOST: http://ccd-user-profile-api-pr-399.service.core-compute-preview.internal
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-13121](https://tools.hmcts.net/jira/browse/RDM-13121) _"Add RefData service lookup checks to GlobalSearch endpoint FTAs"_

### Change description ###

Temporary ELASTIC_SEARCH_HOST override to allow testing of hmcts/ccd-data-store-api#1864.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```