### PR TITLE
RDM-13127 adjust CaseAccessCategory in GS index

### DIFF
--- a/charts/ccd-definition-store-api/values.preview.template.yaml
+++ b/charts/ccd-definition-store-api/values.preview.template.yaml
@@ -22,7 +22,8 @@ java:
     # enable whenever required and provide host url to match with corresponding data-store-api
     ELASTIC_SEARCH_ENABLED: true
 
-    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
+    # TODO: remove TEMPORARY OVERRIDE FOR RDM-13127, reinstate: ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
+    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1889-es-master
 
     USER_PROFILE_HOST: http://ccd-user-profile-api-pr-399.service.core-compute-preview.internal
 

--- a/charts/ccd-definition-store-api/values.preview.template.yaml
+++ b/charts/ccd-definition-store-api/values.preview.template.yaml
@@ -22,8 +22,7 @@ java:
     # enable whenever required and provide host url to match with corresponding data-store-api
     ELASTIC_SEARCH_ENABLED: true
 
-    # TODO: remove TEMPORARY OVERRIDE FOR RDM-13127, reinstate: ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
-    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1889-es-master
+    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
 
     USER_PROFILE_HOST: http://ccd-user-profile-api-pr-399.service.core-compute-preview.internal
 

--- a/elastic-search-support/src/main/resources/globalSearchCasesMapping.json
+++ b/elastic-search-support/src/main/resources/globalSearchCasesMapping.json
@@ -71,9 +71,7 @@
               "ignore_above": 256,
               "normalizer": "lowercase_normalizer"
             }
-          },
-          "analyzer": "standard",
-          "search_analyzer": "alphanumeric_string_analyzer"
+          }
         },
         "SearchCriteria": {
           "type": "object",


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-13127](https://tools.hmcts.net/jira/browse/RDM-13127) _"Access Control - CaseAccessCategory not working for the Global Search endpoint"_

### Change description ###

Adjust how the CaseAccessCategory field is indexed in GlobalSearch so it uses the same analyzer config as the case type indexes.

> **NB: This release will require the GlobalSearch index to be deleted and recreated.**
> NB: This branch is required by: hmcts/ccd-data-store-api#1889

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
