### PR TITLE
PR to fix def-store tests with new def-file

### DIFF
--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.8.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.8.td.json
@@ -35,7 +35,7 @@
           "read_only": true,
           "authorisations": "auth1",
           "access_profiles": "caseworker-befta_master",
-          "live_from": "2017-01-01T00:00:00.000+00:00",
+          "live_from": "[[ANY_DATE_NOT_NULLABLE]]",
           "live_to": null,
           "role_name": "Role1",
           "case_access_categories": "TestValue"
@@ -46,7 +46,7 @@
           "read_only": false,
           "authorisations": "auth1",
           "access_profiles": "caseworker-befta_master",
-          "live_from": "2017-01-01T00:00:00.000+00:00",
+          "live_from": "[[ANY_DATE_NOT_NULLABLE]]",
           "live_to": null,
           "role_name": "Role1",
           "case_access_categories": "Civil/Standard,Criminal/Serious"
@@ -57,7 +57,7 @@
           "read_only": false,
           "authorisations": null,
           "access_profiles": "caseworker-befta_master",
-          "live_from": "2017-01-01T00:00:00.000+00:00",
+          "live_from": "[[ANY_DATE_NOT_NULLABLE]]",
           "live_to": null,
           "role_name": "idam:caseworker-befta_master",
           "case_access_categories": "Civil/Standard,Criminal/Serious"

--- a/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.8.td.json
+++ b/aat/src/aat/resources/features/F-097 RoleToAccessProfiles/S-097.8.td.json
@@ -1,22 +1,18 @@
 {
   "_guid_": "S-097.8",
   "_extends_": "Get_CaseType",
-
   "title": "Return the new CaseAccessCategories column as part of the Get Case Type operation from Definitions store",
-
   "specs": [
     "an active profile in CCD",
     "Get RoleToAccessProfiles",
     "Definition store API",
     "contains the newly defined field - CaseAccessCategories"
   ],
-
   "request": {
     "pathVariables": {
       "id": "FT_CaseAccessCategories"
     }
   },
-
   "expectedResponse": {
     "body": {
       "id": "FT_CaseAccessCategories",
@@ -39,18 +35,40 @@
           "read_only": true,
           "authorisations": "auth1",
           "access_profiles": "caseworker-befta_master",
-          "live_from": "[[ANY_DATE_NOT_NULLABLE]]",
+          "live_from": "2017-01-01T00:00:00.000+00:00",
           "live_to": null,
           "role_name": "Role1",
           "case_access_categories": "TestValue"
+        },
+        {
+          "case_type_id": "FT_CaseAccessCategories",
+          "disabled": false,
+          "read_only": false,
+          "authorisations": "auth1",
+          "access_profiles": "caseworker-befta_master",
+          "live_from": "2017-01-01T00:00:00.000+00:00",
+          "live_to": null,
+          "role_name": "Role1",
+          "case_access_categories": "Civil/Standard,Criminal/Serious"
+        },
+        {
+          "case_type_id": "FT_CaseAccessCategories",
+          "disabled": false,
+          "read_only": false,
+          "authorisations": null,
+          "access_profiles": "caseworker-befta_master",
+          "live_from": "2017-01-01T00:00:00.000+00:00",
+          "live_to": null,
+          "role_name": "idam:caseworker-befta_master",
+          "case_access_categories": "Civil/Standard,Criminal/Serious"
         }
       ],
       "searchParties": [],
       "searchCriterias": [],
       "case_fields": "[[ANYTHING_PRESENT]]",
       "printable_document_url": null,
-      "callback_get_case_url" : null,
-      "retries_get_case_url" : [],
+      "callback_get_case_url": null,
+      "retries_get_case_url": [],
       "security_classification": "PUBLIC"
     }
   }

--- a/aat/src/aat/resources/features/F-103 New DefaultValue Column/S-103.1.td.json
+++ b/aat/src/aat/resources/features/F-103 New DefaultValue Column/S-103.1.td.json
@@ -1,11 +1,11 @@
 {
-	"_guid_": "S-103.1",
+  "_guid_": "S-103.1",
   "_extends_": "Get_CaseType",
-	"title": "Import Definition file with correctly configured DefaultValue in the CaseEventToFields tab",
-	"specs": [
-		"an active profile in CCD",
-		"contains the newly defined field - DefaultValue"
-	],
+  "title": "Import Definition file with correctly configured DefaultValue in the CaseEventToFields tab",
+  "specs": [
+    "an active profile in CCD",
+    "contains the newly defined field - DefaultValue"
+  ],
   "request": {
     "pathVariables": {
       "id": "FT_CaseAccessCategories"
@@ -22,47 +22,123 @@
       },
       "name": "[[ANYTHING_PRESENT]]",
       "jurisdiction": "[[ANYTHING_PRESENT]]",
-      "events" : [ {
-        "id" : "CREATE",
-        "name" : "Create a case",
-        "description" : "Create a case",
-        "order" : "[[ANYTHING_PRESENT]]",
-        "case_fields" : [ {
-          "case_field_id" : "TextField",
-          "display_context" : "OPTIONAL",
-          "display_context_parameter" : null,
-          "retain_hidden_value" : null,
-          "show_condition" : null,
-          "show_summary_change_option" : "[[ANYTHING_PRESENT]]",
-          "show_summary_content_option" : null,
-          "label" : null,
-          "hint_text" : null,
-          "publish" : "[[ANYTHING_PRESENT]]",
-          "publish_as" : null,
-          "default_value" : "DefaultValue test",
-          "case_fields_complex" : "[[ANYTHING_PRESENT]]"
-        } ],
-        "pre_states" : "[[ANYTHING_PRESENT]]",
-        "post_states" : [ {
-          "enabling_condition" : null,
-          "priority" : "[[ANYTHING_PRESENT]]",
-          "post_state_reference" : "CaseCreated"
-        } ],
-        "callback_url_about_to_start_event" : null,
-        "retries_timeout_about_to_start_event" : "[[ANYTHING_PRESENT]]",
-        "callback_url_about_to_submit_event" : null,
-        "retries_timeout_url_about_to_submit_event" : "[[ANYTHING_PRESENT]]",
-        "callback_url_submitted_event" : null,
-        "retries_timeout_url_submitted_event" : "[[ANYTHING_PRESENT]]",
-        "security_classification" : "[[ANYTHING_PRESENT]]",
-        "acls" : "[[ANYTHING_PRESENT]]",
-        "show_summary" : "[[ANYTHING_PRESENT]]",
-        "publish" : "[[ANYTHING_PRESENT]]",
-        "show_event_notes" : null,
-        "can_save_draft" : "[[ANYTHING_PRESENT]]",
-        "end_button_label" : null,
-        "event_enabling_condition" : null
-      } ],
+      "events": [
+        {
+          "id": "UPDATE",
+          "name": "Update a case",
+          "description": "Update a case",
+          "order": "[[ANYTHING_PRESENT]]",
+          "case_fields": [
+            {
+              "case_field_id": "CaseAccessCategory",
+              "display_context": "OPTIONAL",
+              "display_context_parameter": null,
+              "retain_hidden_value": null,
+              "show_condition": null,
+              "show_summary_change_option": "[[ANYTHING_PRESENT]]",
+              "show_summary_content_option": null,
+              "label": null,
+              "hint_text": null,
+              "publish": "[[ANYTHING_PRESENT]]",
+              "publish_as": null,
+              "default_value": null,
+              "case_fields_complex": "[[ANYTHING_PRESENT]]"
+            },
+            {
+              "case_field_id": "TextField",
+              "display_context": "OPTIONAL",
+              "display_context_parameter": null,
+              "retain_hidden_value": null,
+              "show_condition": null,
+              "show_summary_change_option": true,
+              "show_summary_content_option": null,
+              "label": null,
+              "hint_text": null,
+              "publish": false,
+              "publish_as": null,
+              "default_value": null,
+              "case_fields_complex": []
+            }
+          ],
+          "pre_states": [
+            "*"
+          ],
+          "post_states": [
+            {
+              "enabling_condition": null,
+              "priority": 99,
+              "post_state_reference": "*"
+            }
+          ],
+          "callback_url_about_to_start_event": null,
+          "retries_timeout_about_to_start_event": [],
+          "callback_url_about_to_submit_event": null,
+          "retries_timeout_url_about_to_submit_event": [],
+          "callback_url_submitted_event": null,
+          "retries_timeout_url_submitted_event": [],
+          "security_classification": "PUBLIC",
+          "acls": [
+            {
+              "role": "caseworker-befta_master",
+              "create": true,
+              "read": true,
+              "update": true,
+              "delete": true
+            }
+          ],
+          "show_summary": true,
+          "publish": false,
+          "show_event_notes": null,
+          "can_save_draft": false,
+          "end_button_label": null,
+          "event_enabling_condition": null
+        },
+        {
+          "id": "CREATE",
+          "name": "Create a case",
+          "description": "Create a case",
+          "order": "[[ANYTHING_PRESENT]]",
+          "case_fields": [
+            {
+              "case_field_id": "TextField",
+              "display_context": "OPTIONAL",
+              "display_context_parameter": null,
+              "retain_hidden_value": null,
+              "show_condition": null,
+              "show_summary_change_option": "[[ANYTHING_PRESENT]]",
+              "show_summary_content_option": null,
+              "label": null,
+              "hint_text": null,
+              "publish": "[[ANYTHING_PRESENT]]",
+              "publish_as": null,
+              "default_value": "DefaultValue test",
+              "case_fields_complex": "[[ANYTHING_PRESENT]]"
+            }
+          ],
+          "pre_states": "[[ANYTHING_PRESENT]]",
+          "post_states": [
+            {
+              "enabling_condition": null,
+              "priority": "[[ANYTHING_PRESENT]]",
+              "post_state_reference": "CaseCreated"
+            }
+          ],
+          "callback_url_about_to_start_event": null,
+          "retries_timeout_about_to_start_event": "[[ANYTHING_PRESENT]]",
+          "callback_url_about_to_submit_event": null,
+          "retries_timeout_url_about_to_submit_event": "[[ANYTHING_PRESENT]]",
+          "callback_url_submitted_event": null,
+          "retries_timeout_url_submitted_event": "[[ANYTHING_PRESENT]]",
+          "security_classification": "[[ANYTHING_PRESENT]]",
+          "acls": "[[ANYTHING_PRESENT]]",
+          "show_summary": "[[ANYTHING_PRESENT]]",
+          "publish": "[[ANYTHING_PRESENT]]",
+          "show_event_notes": null,
+          "can_save_draft": "[[ANYTHING_PRESENT]]",
+          "end_button_label": null,
+          "event_enabling_condition": null
+        }
+      ],
       "states": "[[ANYTHING_PRESENT]]",
       "acls": "[[ANYTHING_PRESENT]]",
       "searchAliasFields": [],
@@ -71,8 +147,8 @@
       "searchCriterias": [],
       "case_fields": "[[ANYTHING_PRESENT]]",
       "printable_document_url": null,
-      "callback_get_case_url" : null,
-      "retries_get_case_url" : [],
+      "callback_get_case_url": null,
+      "retries_get_case_url": [],
       "security_classification": "PUBLIC"
     }
   }

--- a/aat/src/aat/resources/features/F-103 New DefaultValue Column/S-103.1.td.json
+++ b/aat/src/aat/resources/features/F-103 New DefaultValue Column/S-103.1.td.json
@@ -111,7 +111,7 @@
               "hint_text": null,
               "publish": "[[ANYTHING_PRESENT]]",
               "publish_as": null,
-              "default_value": "[[ANYTHING_PRESENT]]",
+              "default_value": null,
               "case_fields_complex": []
             },
             {
@@ -126,7 +126,7 @@
               "hint_text": null,
               "publish": "[[ANYTHING_PRESENT]]",
               "publish_as": null,
-              "default_value": "[[ANYTHING_PRESENT]]",
+              "default_value": null,
               "case_fields_complex": "[[ANYTHING_PRESENT]]"
             }
           ],

--- a/aat/src/aat/resources/features/F-103 New DefaultValue Column/S-103.1.td.json
+++ b/aat/src/aat/resources/features/F-103 New DefaultValue Column/S-103.1.td.json
@@ -97,8 +97,23 @@
           "id": "CREATE",
           "name": "Create a case",
           "description": "Create a case",
-          "order": "[[ANYTHING_PRESENT]]",
+          "order": 1,
           "case_fields": [
+            {
+              "case_field_id": "CaseAccessCategory",
+              "display_context": "OPTIONAL",
+              "display_context_parameter": null,
+              "retain_hidden_value": null,
+              "show_condition": null,
+              "show_summary_change_option": "[[ANYTHING_PRESENT]]",
+              "show_summary_content_option": null,
+              "label": null,
+              "hint_text": null,
+              "publish": "[[ANYTHING_PRESENT]]",
+              "publish_as": null,
+              "default_value": "[[ANYTHING_PRESENT]]",
+              "case_fields_complex": []
+            },
             {
               "case_field_id": "TextField",
               "display_context": "OPTIONAL",
@@ -111,7 +126,7 @@
               "hint_text": null,
               "publish": "[[ANYTHING_PRESENT]]",
               "publish_as": null,
-              "default_value": "DefaultValue test",
+              "default_value": "[[ANYTHING_PRESENT]]",
               "case_fields_complex": "[[ANYTHING_PRESENT]]"
             }
           ],

--- a/build.gradle
+++ b/build.gradle
@@ -272,7 +272,7 @@ subprojects { subproject ->
         testCompile "io.rest-assured:rest-assured:${restAssuredVersion}"
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.13.0'
+        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.14.1-prerelease'
         testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.2-Categories'
         testCompile group: 'commons-lang', name: 'commons-lang', version: '2.6'
         // https://mvnrepository.com/artifact/junit/junit

--- a/build.gradle
+++ b/build.gradle
@@ -266,7 +266,7 @@ subprojects { subproject ->
         testCompile "io.rest-assured:rest-assured:${restAssuredVersion}"
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
-        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.14.1-prerelease'
+        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.14.1'
         testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.2-Categories'
         testCompile group: 'commons-lang', name: 'commons-lang', version: '2.6'
         // https://mvnrepository.com/artifact/junit/junit

--- a/charts/ccd-definition-store-api/Chart.yaml
+++ b/charts/ccd-definition-store-api/Chart.yaml
@@ -2,11 +2,11 @@ description: Helm chart for the HMCTS CCD Definition Store
 name: ccd-definition-store-api
 apiVersion: v2
 home: https://github.com/hmcts/ccd-definition-store-api
-version: 1.6.1
+version: 1.6.2
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET
 dependencies:
   - name: java
-    version: 3.7.1
+    version: 3.7.3
     repository: '@hmctspublic'


### PR DESCRIPTION
### Change description ###

FT patch for tests to pass with the new def file [7.14.1](https://github.com/hmcts/ccd-test-definitions/releases/tag/7.14.1)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
