### PR TITLE
ccd-2533: Fix Flaky Functional Tests in Definition Store

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,7 @@
 
 properties([
     // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-    pipelineTriggers([cron('H 05 * * *')])
+    pipelineTriggers([cron('30 21 * * *')])
 ])
 
 @Library("Infrastructure")


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-2533

### Change description ###

Fix Flaky Functional Tests by setting the cron schedule to 21:30 PM not to interfere the running tests and cause data corruption. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
