### PR TITLE
RDM-13140 test definition release for getLinkedCases API

### DIFF
--- a/aat/src/aat/resources/features/F-102 - TTL Base Complex Type/S-102.2.td.json
+++ b/aat/src/aat/resources/features/F-102 - TTL Base Complex Type/S-102.2.td.json
@@ -635,6 +635,23 @@
         "display_context_parameter" : null,
         "retain_hidden_value" : null
       }, {
+        "metadata" : false,
+        "id" : "caseNameHmctsInternal",
+        "case_type_id" : "FT_MasterCaseType",
+        "label" : "Case Name HMCTS Internal",
+        "hint_text" : null,
+        "field_type" : "[[ANYTHING_PRESENT]]",
+        "hidden" : false,
+        "security_classification" : "PUBLIC",
+        "live_from" : "[[ANYTHING_PRESENT]]",
+        "live_until" : null,
+        "acls" : "[[ANYTHING_PRESENT]]",
+        "complexACLs" : [ ],
+        "order" : null,
+        "show_condition" : null,
+        "display_context_parameter" : null,
+        "retain_hidden_value" : null
+      }, {
         "metadata" : true,
         "id" : "[CASE_REFERENCE]",
         "case_type_id" : null,

--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ subprojects { subproject ->
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
 
-        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.18.1-prerelease'
+        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.0'
         testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.2-Categories'
 
         testCompile group: 'commons-lang', name: 'commons-lang', version: '2.6'

--- a/build.gradle
+++ b/build.gradle
@@ -270,7 +270,7 @@ subprojects { subproject ->
         testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: powermockVersion
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
 
-        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.16.1'
+        testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.17.1_RDM-13140'
         testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.2-Categories'
 
         testCompile group: 'commons-lang', name: 'commons-lang', version: '2.6'

--- a/charts/ccd-definition-store-api/values.preview.template.yaml
+++ b/charts/ccd-definition-store-api/values.preview.template.yaml
@@ -23,8 +23,7 @@ java:
     # enable whenever required and provide host url to match with corresponding data-store-api
     ELASTIC_SEARCH_ENABLED: true
 
-    # TODO: remove TEMPORARY OVERRIDE for RDM-13140, reinstate: ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
-    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1961-es-master
+    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
 
     USER_PROFILE_HOST: http://ccd-user-profile-api-pr-399.service.core-compute-preview.internal
 

--- a/charts/ccd-definition-store-api/values.preview.template.yaml
+++ b/charts/ccd-definition-store-api/values.preview.template.yaml
@@ -23,7 +23,8 @@ java:
     # enable whenever required and provide host url to match with corresponding data-store-api
     ELASTIC_SEARCH_ENABLED: true
 
-    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
+    # TODO: remove TEMPORARY OVERRIDE for RDM-13140, reinstate: ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1260-es-master
+    ELASTIC_SEARCH_HOST: ccd-data-store-api-pr-1961-es-master
 
     USER_PROFILE_HOST: http://ccd-user-profile-api-pr-399.service.core-compute-preview.internal
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-13140](https://tools.hmcts.net/jira/browse/RDM-13140) _"getLinkedCases API - retrieve case links from database and return response payload"_

### Change description ###

Build against the next `ccd-test-definitions` pre-release, see hmcts/ccd-test-definitions#47.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
