### PR TITLE
CVE-2022-23708:ccd-definition-store-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencyCheck {
 
 //spring boot dependency override
 //overriding some default spring boot deps because too old. Not generally recommended but needed to prevent runtime errors with version 6.4.2 of Elastic
-ext['elasticsearch.version'] = '7.16.2'
+ext['elasticsearch.version'] = '7.17.1'
 ext['javax-validation.version'] = '2.0.1.Final'
 ext['hibernate-validator.version'] = '6.0.20.Final'
 ext['spring-security.version'] = '5.4.7'
@@ -104,7 +104,7 @@ allprojects {
     apply plugin: 'java'
 
     ext {
-        elasticSearchVersion = '7.16.2'
+        elasticSearchVersion = '7.17.1'
     }
 
     dependencies {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -64,14 +64,6 @@
 
 	<suppress until="2022-05-25">
 		<notes><![CDATA[
-   file name: elasticsearch-7.16.2.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch@.*$</packageUrl>
-		<vulnerabilityName>CVE-2022-23708</vulnerabilityName>
-	</suppress>
-
-	<suppress until="2022-05-25">
-		<notes><![CDATA[
    file name: spring-core-5.3.18.jar
    ]]></notes>
 		<packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3100

### Change description ###

A flaw was discovered in Elasticsearch 7.17.0’s upgrade assistant, in which upgrading from version 6.x to 7.x would disable the in-built protections on the security index, allowing authenticated users with “*” index permissions access to this index.
Upgraded to 7.17.1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
