### PR TITLE
CCD-3099: Updated spring-framework.version to 5.3.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext['snakeyaml.version'] = '1.26'
 ext['postgresql.version'] = '42.2.16'
 //overriding log4j2 default version 2.7 because of vulnerability issues
 ext['log4j2.version'] = '2.17.1'
-ext['spring-framework.version'] = '5.3.18'
+ext['spring-framework.version'] = '5.3.19'
 
 // end
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -62,11 +62,4 @@
 		<cve>CVE-2022-21724</cve>
 	</suppress>
 
-	<suppress until="2022-05-25">
-		<notes><![CDATA[
-   file name: spring-core-5.3.18.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-		<cve>CVE-2022-22968</cve>
-	</suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3099

### Change description ###

1. Updated spring-framework.version t0 5.3.19
2. Remove suppression for CVE-2022-22968

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
