### PR TITLE
CCD-3086 Add JDK 17 to BEFTA Framework - befta pre release dependency…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,7 @@ subprojects { subproject ->
         testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
 
         testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.0'
-        testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.2-Categories'
+        testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.2-CCD-3086.8'
 
         testCompile group: 'commons-lang', name: 'commons-lang', version: '2.6'
         // https://mvnrepository.com/artifact/junit/junit

--- a/charts/ccd-definition-store-api/Chart.yaml
+++ b/charts/ccd-definition-store-api/Chart.yaml
@@ -2,11 +2,11 @@ description: Helm chart for the HMCTS CCD Definition Store
 name: ccd-definition-store-api
 apiVersion: v2
 home: https://github.com/hmcts/ccd-definition-store-api
-version: 1.6.2
+version: 1.6.3
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET
 dependencies:
   - name: java
     version: 3.7.3
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'


### PR DESCRIPTION
CCD-3086 Add JDK 17 to BEFTA Framework - befta pre release dependency used in build.gradle

https://tools.hmcts.net/jira/browse/CCD-3086

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
