### PR TITLE
CVE-2022-21724 ccd-definition-store fix

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -29,7 +29,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile "org.flywaydb:flyway-core:6.5.7"
-    runtime group: 'org.postgresql', name: 'postgresql', version: '42.2.16'
+    runtime group: 'org.postgresql', name: 'postgresql', version: '42.3.5'
 
     testCompile project(":app-insights").sourceSets.main.output
     testCompile project(":commons").sourceSets.main.output

--- a/build.gradle
+++ b/build.gradle
@@ -248,7 +248,7 @@ subprojects { subproject ->
         // To avoid compiler warnings about @API annotations in JUnit5 code.
         testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
         testCompile "org.postgresql:postgresql:42.3.3"
-        testCompile "org.testcontainers:postgresql:1.15.1"
+        testCompile "org.testcontainers:postgresql:1.17.2"
         testCompile "org.hamcrest:hamcrest-core:${hamcrestVersion}"
         testCompile "org.hamcrest:hamcrest-library:${hamcrestVersion}"
         testCompile "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext['hibernate-validator.version'] = '6.0.20.Final'
 ext['spring-security.version'] = '5.4.7'
 ext['jackson.version'] = '2.13.2'
 ext['snakeyaml.version'] = '1.26'
-ext['postgresql.version'] = '42.3.2'
+ext['postgresql.version'] = '42.3.3'
 //overriding log4j2 default version 2.7 because of vulnerability issues
 ext['log4j2.version'] = '2.17.1'
 ext['spring-framework.version'] = '5.3.19'
@@ -247,7 +247,7 @@ subprojects { subproject ->
 
         // To avoid compiler warnings about @API annotations in JUnit5 code.
         testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
-        testCompile "org.postgresql:postgresql:42.3.2"
+        testCompile "org.postgresql:postgresql:42.3.3"
         testCompile "org.testcontainers:postgresql:1.15.1"
         testCompile "org.hamcrest:hamcrest-core:${hamcrestVersion}"
         testCompile "org.hamcrest:hamcrest-library:${hamcrestVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext['hibernate-validator.version'] = '6.0.20.Final'
 ext['spring-security.version'] = '5.4.7'
 ext['jackson.version'] = '2.13.2'
 ext['snakeyaml.version'] = '1.26'
-ext['postgresql.version'] = '42.2.16'
+ext['postgresql.version'] = '42.3.2'
 //overriding log4j2 default version 2.7 because of vulnerability issues
 ext['log4j2.version'] = '2.17.1'
 ext['spring-framework.version'] = '5.3.19'
@@ -247,7 +247,7 @@ subprojects { subproject ->
 
         // To avoid compiler warnings about @API annotations in JUnit5 code.
         testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
-        testCompile "org.postgresql:postgresql:42.2.16"
+        testCompile "org.postgresql:postgresql:42.3.2"
         testCompile "org.testcontainers:postgresql:1.15.1"
         testCompile "org.hamcrest:hamcrest-core:${hamcrestVersion}"
         testCompile "org.hamcrest:hamcrest-library:${hamcrestVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext['hibernate-validator.version'] = '6.0.20.Final'
 ext['spring-security.version'] = '5.4.7'
 ext['jackson.version'] = '2.13.2'
 ext['snakeyaml.version'] = '1.26'
-ext['postgresql.version'] = '42.3.3'
+ext['postgresql.version'] = '42.3.5'
 //overriding log4j2 default version 2.7 because of vulnerability issues
 ext['log4j2.version'] = '2.17.1'
 ext['spring-framework.version'] = '5.3.19'
@@ -247,7 +247,7 @@ subprojects { subproject ->
 
         // To avoid compiler warnings about @API annotations in JUnit5 code.
         testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
-        testCompile "org.postgresql:postgresql:42.3.3"
+        testCompile "org.postgresql:postgresql:42.3.5"
         testCompile "org.testcontainers:postgresql:1.17.2"
         testCompile "org.hamcrest:hamcrest-core:${hamcrestVersion}"
         testCompile "org.hamcrest:hamcrest-library:${hamcrestVersion}"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -53,15 +53,6 @@
     		<packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-core@.*$</packageUrl>
     		<vulnerabilityName>CWE-862: Missing Authorization</vulnerabilityName>
   	</suppress>
-
-	<suppress until="2022-06-25">
-		<notes><![CDATA[
-   file name: postgresql-42.2.16.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
-		<cve>CVE-2022-21724</cve>
-	</suppress>
-
 	<suppress until="2022-06-25">
 		<notes><![CDATA[
    file name: spring-core-5.3.18.jar

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testCompile ("io.springfox:springfox-boot-starter:${springfoxSwaggerVersion}") {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    testCompile  group: 'org.postgresql', name: 'postgresql', version: '42.2.16'
+    testCompile  group: 'org.postgresql', name: 'postgresql', version: '42.3.5'
 }
 
 // To help obscure gradle problem


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-2919

Upgrading to version postgresql:42.3.2.
https://nvd.nist.gov/vuln/detail/CVE-2022-21724
A security hole was found in the jdbc driver for postgresql database while doing security research

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
