### PR TITLE
CVE-2022-29885: ccd-definition-store-api fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
     reformLogging= '5.1.9'
     restAssuredVersion = '4.3.0!!'
     groovyVersion = '3.0.2!!'
-    tomcatVersion = '9.0.58!!'
+    tomcatVersion = '9.0.63!!'
     hibernateVersion = '5.4.24.Final!!'
     feignJackson = '11.6'
     limits = [

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -53,21 +53,7 @@
     		<packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-core@.*$</packageUrl>
     		<vulnerabilityName>CWE-862: Missing Authorization</vulnerabilityName>
   	</suppress>
-	<suppress until="2022-06-25">
-		<notes><![CDATA[
-   file name: tomcat-embed-core-9.0.58.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-		<cve>CVE-2022-29885</cve>
-	</suppress>
 
-	<suppress until="2022-06-25">
-		<notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.58.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-		<cve>CVE-2022-29885</cve>
-	</suppress>
 	<suppress until="2022-06-25">
 		<notes><![CDATA[
    file name: spring-core-5.3.19.jar


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3266

Upgrading tomcat version to 9.0.63.
The documentation of Apache Tomcat 10.1.0-M1 to 10.1.0-M14, 10.0.0-M1 to 10.0.20, 9.0.13 to 9.0.62 and 8.5.38 to 8.5.78 for the EncryptInterceptor incorrectly stated it enabled Tomcat clustering to run over an untrusted network. This was not correct. While the EncryptInterceptor does provide confidentiality and integrity protection, it does not protect against all risks associated with running over any untrusted network, particularly DoS risks.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
