### PR TITLE
CCD-3539-CCD-3574: Stop running Nightly builds on weekends, Removal of FTs

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,8 @@
 
 properties([
     // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-    pipelineTriggers([cron('H 05 * * *')])
+    //CCD-3539 (Stop running Nightly builds on weekends). Original schedule was 'H 05 * * *'
+    pipelineTriggers([cron('H 05 * * 1-5')])
 ])
 
 @Library("Infrastructure")

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -77,10 +77,5 @@ withNightlyPipeline(type, product, component) {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/checkstyle/*.html'
     }
 
-    enableFullFunctionalTest(200)
-
-    after('fullFunctionalTest') {
-        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/BEFTA Report for Functional Tests/**/*'
-    }
     enableSlackNotifications('#ccd-nightly-builds')
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3539
https://tools.hmcts.net/jira/browse/CCD-3574

### Change description ###

CCD-3539: Stop running Nightly builds on weekends
CCD-3574: Remove FTs from nightly pipeline build

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
