### PR TITLE
CCD-3429 CVE-2022-34305 suppression moved from temp to false positive

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -14,6 +14,7 @@
 			CVE-2007-1652 https://tools.hmcts.net/jira/browse/CCD-175
 			CVE-2016-1000027 https://tools.hmcts.net/jira/browse/CCD-3251
 			CVE-2022-33915 https://tools.hmcts.net/jira/browse/CCD-3440
+			CVE-2022-34305 https://tools.hmcts.net/jira/browse/CCD-3429
 		</notes>
 		<cve>CVE-2020-23171</cve>
 		<cve>CVE-2018-1258</cve>
@@ -25,13 +26,13 @@
 		<cve>CVE-2007-1652</cve>
 		<cve>CVE-2016-1000027</cve>
 		<cve>CVE-2022-33915</cve>
+		<cve>CVE-2022-34305</cve>
 	</suppress>
 	<!--End of false positives section -->
 
 	<!--Please add all the temporary suppression under the below section-->
 	  <suppress>
 	    <notes>Temporary Suppression
-	      	CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3429
 			CVE-2022-31569  refer https://tools.hmcts.net/jira/browse/CCD-3536
 			CVE-2022-22969 refer https://tools.hmcts.net/jira/browse/CCD-3512
 			CVE-2022-22978 refer https://tools.hmcts.net/jira/browse/CCD-3513
@@ -40,7 +41,6 @@
 			CVE-2021-22044 refer https://tools.hmcts.net/jira/browse/CCD-3509
 			CVE-2022-31197 refer https://tools.hmcts.net/jira/browse/CCD-3604
  	    </notes>
-	    <cve>CVE-2022-34305</cve>
 	    <cve>CVE-2022-31569</cve>
 	    <cve>CVE-2022-22969</cve>
 	    <cve>CVE-2022-22978</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3429
CVE-2022-34305 suppression moved to false positive

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
