### PR TITLE
CCD-3604: CVE-2022-31197 - Upgraded org.postgresql to 42.4.1 and removed temp suppression

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -29,7 +29,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile "org.flywaydb:flyway-core:6.5.7"
-    runtime group: 'org.postgresql', name: 'postgresql', version: '42.3.5'
+    runtime group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
 
     testCompile project(":app-insights").sourceSets.main.output
     testCompile project(":commons").sourceSets.main.output

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext['hibernate-validator.version'] = '6.0.20.Final'
 ext['spring-security.version'] = '5.6.6'
 ext['jackson.version'] = '2.13.2'
 ext['snakeyaml.version'] = '1.26'
-ext['postgresql.version'] = '42.3.5'
+ext['postgresql.version'] = '42.4.1'
 //overriding log4j2 default version 2.7 because of vulnerability issues
 ext['log4j2.version'] = '2.17.1'
 ext['spring-framework.version'] = '5.3.20'
@@ -252,7 +252,7 @@ subprojects { subproject ->
 
         // To avoid compiler warnings about @API annotations in JUnit5 code.
         testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
-        testCompile "org.postgresql:postgresql:42.3.5"
+        testCompile "org.postgresql:postgresql:42.4.1"
         testCompile "org.testcontainers:postgresql:1.17.2"
         testCompile "org.hamcrest:hamcrest-core:${hamcrestVersion}"
         testCompile "org.hamcrest:hamcrest-library:${hamcrestVersion}"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -38,7 +38,6 @@
 			CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514
 			CVE-2022-22976 refer https://tools.hmcts.net/jira/browse/CCD-3515
 			CVE-2021-22044 refer https://tools.hmcts.net/jira/browse/CCD-3509
-			CVE-2022-31197 refer https://tools.hmcts.net/jira/browse/CCD-3604
  	    </notes>
 	    <cve>CVE-2022-34305</cve>
 	    <cve>CVE-2022-31569</cve>
@@ -47,7 +46,6 @@
 	    <cve>CVE-2021-22112</cve>
 	    <cve>CVE-2022-22976</cve>
 	    <cve>CVE-2021-22044</cve>
-		<cve>CVE-2022-31197</cve>
 	  </suppress>
 	<!--End of temporary suppression section -->
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testCompile ("io.springfox:springfox-boot-starter:${springfoxSwaggerVersion}") {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    testCompile  group: 'org.postgresql', name: 'postgresql', version: '42.3.5'
+    testCompile  group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
 }
 
 // To help obscure gradle problem


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3604

### Change description ###

CCD-3604: CVE-2022-31197 - Upgraded org.postgresql to 42.4.1 and removed temp suppression

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
