### PR TITLE
CCD-3429 CVE-2022-34305 tomcat upgrade 9.0.65, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
     reformLogging= '5.1.9'
     restAssuredVersion = '4.3.0!!'
     groovyVersion = '3.0.2!!'
-    tomcatVersion = '9.0.63!!'
+    tomcatVersion = '9.0.65!!'
     hibernateVersion = '5.4.24.Final!!'
     feignJackson = '11.6'
     limits = [

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -9,14 +9,12 @@
 			CVE-2022-22978 refer https://tools.hmcts.net/jira/browse/CCD-3513
 			CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514
 			CVE-2022-22976 refer https://tools.hmcts.net/jira/browse/CCD-3515
-			CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3429
 		</notes>
 		<cve>CVE-2018-1258</cve>
 		<cve>CVE-2016-1000027</cve>
 		<cve>CVE-2022-22978</cve>
 		<cve>CVE-2021-22112</cve>
 		<cve>CVE-2022-22976</cve>
-		<cve>CVE-2022-34305</cve>
 	</suppress>
 	<!--End of false positives section -->
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3429
CVE-2022-34305 tomcat upgrade 9.0.65

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
