### PR TITLE
Fix Parser performance issue

### DIFF
--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParser.java
@@ -43,7 +43,9 @@ class AuthorisationCaseEventParser implements AuthorisationParser {
         validateCaseTypes(definitionSheets, dataItemMap);
         validateCaseEvents(definitionSheets, definitionSheet, caseTypeReference);
 
-        final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
+        final List<DefinitionDataItem> dataItems = dataItemMap.getOrDefault(caseTypeReference, List.of());
+        final Map<String, List<DefinitionDataItem>> collect =
+                dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_EVENT_ID)));
 
         for (EventEntity event : events) {
             final List<EventACLEntity> parseResults = Lists.newArrayList();
@@ -52,14 +54,11 @@ class AuthorisationCaseEventParser implements AuthorisationParser {
             LOG.debug("Parsing AuthorisationCaseEvent for case type {}, event {}...",
                 caseTypeReference, eventReference);
 
-            if (null == dataItems || dataItems.isEmpty()) {
+            if (dataItems.isEmpty()) {
                 LOG.warn("No data is found for case type '{}' in AuthorisationCaseEvents tab", caseTypeReference);
             } else {
                 LOG.debug("Parsing access profiles for case type {}: {} AuthorisationCaseEvents detected",
                     caseTypeReference, dataItems.size());
-
-                final Map<String, List<DefinitionDataItem>> collect =
-                    dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_EVENT_ID)));
 
                 List<DefinitionDataItem> definitionDataItems = collect.get(eventReference);
 

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseStateParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseStateParser.java
@@ -51,9 +51,9 @@ class AuthorisationCaseStateParser implements AuthorisationParser {
         final Map<String, List<DefinitionDataItem>> dataItemMap = definitionSheet.groupDataItemsByCaseType();
         validateCaseTypes(definitionSheets, dataItemMap);
         validateStates(definitionSheets, definitionSheet, caseTypeReference);
-        final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
+        final List<DefinitionDataItem> dataItems = dataItemMap.getOrDefault(caseTypeReference, List.of());
 
-        if (null == dataItems) {
+        if (dataItems.isEmpty()) {
             LOG.warn("No row were defined for case state '{}' in AuthorisationCaseState tab", stateReference);
         } else {
             LOG.debug("Parsing access profiles for case state {}: {} AuthorisationCaseSate detected",

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationComplexTypeParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationComplexTypeParser.java
@@ -49,9 +49,9 @@ class AuthorisationComplexTypeParser implements AuthorisationParser {
             validateCaseTypes(definitionSheets, dataItemMap);
             validateCaseFields(definitionSheets, definitionSheet, caseTypeReference);
 
-            final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
+            final List<DefinitionDataItem> dataItems = dataItemMap.getOrDefault(caseTypeReference, List.of());
 
-            if (null == dataItems) {
+            if (dataItems.isEmpty()) {
                 LOG.warn("No data is found for case type '{} in AuthorisationComplexTypes tab", caseTypeReference);
             } else {
                 LOG.debug("Parsing access profiles for case type '{}': '{}' AuthorisationComplexTypes detected",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-3657


### Change description ###
Stop Parser from grouping the same set of items on each loop. Items are now retrieved once.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
