### PR TITLE
CCD-3776: Suppress CVE-2022-42003 and CVE-2022-42004

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -19,7 +19,14 @@
 	<!--End of false positives section -->
 
 	<!--Please add all the temporary suppression under the below section-->
-
+	<suppress>
+		<notes>Temporary Suppression
+			CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/CCD-3776
+			CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/CCD-3776
+		</notes>
+		<cve>CVE-2022-42003</cve>
+		<cve>CVE-2022-42004</cve>
+	</suppress>
 	<!--End of temporary suppression section -->
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3776 (https://tools.hmcts.net/jira/browse/CCD-3776)


### Change description ###
Updated suppressions file to temporarily suppress CVE-2022-42003 and CVE-2022-42004 pending fix.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
