### PR TITLE
Demo - Temporary - DO NOT MERGE!!

### DIFF
--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseEventParser.java
@@ -43,7 +43,9 @@ class AuthorisationCaseEventParser implements AuthorisationParser {
         validateCaseTypes(definitionSheets, dataItemMap);
         validateCaseEvents(definitionSheets, definitionSheet, caseTypeReference);
 
-        final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
+        final List<DefinitionDataItem> dataItems = dataItemMap.getOrDefault(caseTypeReference, List.of());
+        final Map<String, List<DefinitionDataItem>> collect =
+                dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_EVENT_ID)));
 
         for (EventEntity event : events) {
             final List<EventACLEntity> parseResults = Lists.newArrayList();
@@ -52,14 +54,11 @@ class AuthorisationCaseEventParser implements AuthorisationParser {
             LOG.debug("Parsing AuthorisationCaseEvent for case type {}, event {}...",
                 caseTypeReference, eventReference);
 
-            if (null == dataItems || dataItems.isEmpty()) {
+            if (dataItems.isEmpty()) {
                 LOG.warn("No data is found for case type '{}' in AuthorisationCaseEvents tab", caseTypeReference);
             } else {
                 LOG.debug("Parsing access profiles for case type {}: {} AuthorisationCaseEvents detected",
                     caseTypeReference, dataItems.size());
-
-                final Map<String, List<DefinitionDataItem>> collect =
-                    dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_EVENT_ID)));
 
                 List<DefinitionDataItem> definitionDataItems = collect.get(eventReference);
 

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseFieldParser.java
@@ -38,7 +38,9 @@ class AuthorisationCaseFieldParser implements AuthorisationParser {
         final String caseTypeReference = caseType.getReference();
         validateCaseFields(definitionSheets, definitionSheet, caseTypeReference);
 
-        final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
+        final List<DefinitionDataItem> dataItems = dataItemMap.getOrDefault(caseTypeReference, List.of());
+        final Map<String, List<DefinitionDataItem>> collect =
+            dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_FIELD_ID)));
 
         for (CaseFieldEntity caseField : caseFields) {
             final List<CaseFieldACLEntity> parseResults = Lists.newArrayList();
@@ -47,14 +49,12 @@ class AuthorisationCaseFieldParser implements AuthorisationParser {
             LOG.debug("Parsing AuthorisationCaseField for case type {}, caseField {}...",
                 caseTypeReference, caseFieldReference);
 
-            if (null == dataItems || dataItems.isEmpty()) {
+            if (dataItems.isEmpty()) {
                 LOG.warn("No data is found for case type '{}' in AuthorisationCaseFields tab", caseTypeReference);
             } else {
                 LOG.debug("Parsing access profiles for case type '{}': '{}' AuthorisationCaseFields detected",
                     caseTypeReference, dataItems.size());
 
-                final Map<String, List<DefinitionDataItem>> collect =
-                    dataItems.stream().collect(groupingBy(d -> d.getString(ColumnName.CASE_FIELD_ID)));
 
                 List<DefinitionDataItem> definitionDataItems = collect.get(caseFieldReference);
 

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseStateParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationCaseStateParser.java
@@ -51,9 +51,9 @@ class AuthorisationCaseStateParser implements AuthorisationParser {
         final Map<String, List<DefinitionDataItem>> dataItemMap = definitionSheet.groupDataItemsByCaseType();
         validateCaseTypes(definitionSheets, dataItemMap);
         validateStates(definitionSheets, definitionSheet, caseTypeReference);
-        final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
+        final List<DefinitionDataItem> dataItems = dataItemMap.getOrDefault(caseTypeReference, List.of());
 
-        if (null == dataItems) {
+        if (dataItems.isEmpty()) {
             LOG.warn("No row were defined for case state '{}' in AuthorisationCaseState tab", stateReference);
         } else {
             LOG.debug("Parsing access profiles for case state {}: {} AuthorisationCaseSate detected",

--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationComplexTypeParser.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/parser/AuthorisationComplexTypeParser.java
@@ -49,9 +49,9 @@ class AuthorisationComplexTypeParser implements AuthorisationParser {
             validateCaseTypes(definitionSheets, dataItemMap);
             validateCaseFields(definitionSheets, definitionSheet, caseTypeReference);
 
-            final List<DefinitionDataItem> dataItems = dataItemMap.get(caseTypeReference);
+            final List<DefinitionDataItem> dataItems = dataItemMap.getOrDefault(caseTypeReference, List.of());
 
-            if (null == dataItems) {
+            if (dataItems.isEmpty()) {
                 LOG.warn("No data is found for case type '{} in AuthorisationComplexTypes tab", caseTypeReference);
             } else {
                 LOG.debug("Parsing access profiles for case type '{}': '{}' AuthorisationComplexTypes detected",


### PR DESCRIPTION
* Fix AuthorisationCaseFieldParser performance issue

This parser was grouping the same set of thousands of items on each case field iteration.

Doing this once reduces total definition import time ~30% in my testing.

* Fix performance issue (#1290)

- Stop Parser from grouping the same set of items on each loop. Items are now retrieved once.

Co-authored-by: Alex McAusland <a.m@user.com>
Co-authored-by: Rajaram <70951210+rajaram-nagarajan@users.noreply.github.com>
Co-authored-by: banderous <alex.mcausland@gmail.com>
Co-authored-by: Marvin <18750678+marvincudjoe@users.noreply.github.com>

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
