### PR TITLE
HMAN-493 run existing FTAs against a BEFTA pre-release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,7 @@ subprojects { subproject ->
         testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
 
         testImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.9'
-        testImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.9-prerelease-HMAN-493' 
+        testImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.10-prerelease-HMAN-493'
 
         testImplementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -274,8 +274,7 @@ subprojects { subproject ->
         testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
 
         testImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.9'
-
-        implementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.6'
+        testImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.9-prerelease-HMAN-493'
 
         testImplementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,7 @@ subprojects { subproject ->
         testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
 
         testImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.9'
-        testImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.9-prerelease-HMAN-493'
+        testImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.9-prerelease-HMAN-493' 
 
         testImplementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-493](https://tools.hmcts.net/jira/browse/HMAN-493) "Next Hearing Date Updater - for preview pipelines enable cleanup of helm release on success"

### Change description ###

Build against the next `befta-fw` pre-release, see hmcts/befta-fw#195.

> see also:
>
> * hmcts/ccd-data-store-api#2180

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
