### PR TITLE
CCD-4163 Bump rse-gradle-java-plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
     id "info.solidsoft.pitest" version '1.5.1' apply(false)
     id "org.jetbrains.gradle.plugin.idea-ext" version "0.7"
-    id 'uk.gov.hmcts.java' version '0.12.28'
+    id 'uk.gov.hmcts.java' version '0.12.37'
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4163

### Change description ###
Bump rse-gradle-java-plugin to 0.12.37

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
