### PR TITLE
CCD-4157 CVE-2022-3064 CVE-2021-4235 moved to false positive

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -6,23 +6,23 @@
 			CVE-2022-22978 refer https://tools.hmcts.net/jira/browse/CCD-3513
 			CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514
 			CVE-2022-22976 refer https://tools.hmcts.net/jira/browse/CCD-3515
+            CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
+            CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157
 		</notes>
     <cve>CVE-2018-1258</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2021-22112</cve>
     <cve>CVE-2022-22976</cve>
+    <cve>CVE-2022-3064</cve>
+    <cve>CVE-2021-4235</cve>
   </suppress>
   <suppress>
     <notes>Temporary Suppression
         CVE-2021-37533 refer [Ticket]
         CVE-2021-4277 refer [Ticket]
-        CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
-        CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157
         CVE-2022-45143 refer [Ticket]</notes>
     <cve>CVE-2021-37533</cve>
     <cve>CVE-2021-4277</cve>
-    <cve>CVE-2022-3064</cve>
-    <cve>CVE-2021-4235</cve>
     <cve>CVE-2022-45143</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4157
CVE-2022-3064 CVE-2021-4235 moved to false positive

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
