### PR TITLE
CCD-4283: Bump gradle-java-plugin to 0.12.40

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
     id "info.solidsoft.pitest" version '1.5.1' apply(false)
     id "org.jetbrains.gradle.plugin.idea-ext" version "0.7"
-    id 'uk.gov.hmcts.java' version '0.12.37'
+    id 'uk.gov.hmcts.java' version '0.12.40'
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4283

### Change description ###
Bump gradle-java-plugin to 0.12.40

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```