### PR TITLE
CCD-4476 : replaced reform-api-docs to cnp-api-docs

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -31,7 +31,7 @@ jobs:
           git init
           git config user.email "github-actions@users.noreply.github.com"
           git config user.name "GitHub action"
-          git remote add upstream "https://jenkins-reform-hmcts:${{ secrets.GH_TOKEN }}@github.com/hmcts/reform-api-docs.git"
+          git remote add upstream "https://jenkins-reform-hmcts:${{ secrets.GH_TOKEN }}@github.com/hmcts/cnp-api-docs.git"
           git pull upstream master
           repo=`echo "$GITHUB_REPOSITORY" | cut -f2- -d/`
           echo "$(cat /tmp/ccd-definition-store-api.json)" > "docs/specs/ccd-definition-store-api.json"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ccd-case-definition-store-api
-[![API Docs](https://img.shields.io/badge/API%20Docs-site-e140ad.svg)](https://hmcts.github.io/reform-api-docs/swagger.html?url=https://hmcts.github.io/reform-api-docs/specs/ccd-definition-store-api.json)
+[![API Docs](https://img.shields.io/badge/API%20Docs-site-e140ad.svg)](https://hmcts.github.io/cnp-api-docs/swagger.html?url=https://hmcts.github.io/cnp-api-docs/specs/ccd-definition-store-api.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://api.travis-ci.org/hmcts/ccd-definition-store-api.svg?branch=master)](https://travis-ci.org/hmcts/ccd-definition-store-api)
 [![Docker Build Status](https://img.shields.io/docker/build/hmcts/ccd-definition-store-api.svg)](https://hub.docker.com/r/hmcts/ccd-definition-store-api)


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4476

### Change description ###

CCD-4476 : replaced reform-api-docs to cnp-api-docs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
