### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext {
     springfoxSwaggerVersion = '3.0.0'
     hamcrestVersion = '1.3'
     powermockVersion = '2.0.0-beta.5'
-    reformLogging= '5.1.9'
+    reformLogging= '6.0.1'
     restAssuredVersion = '4.3.0!!'
     groovyVersion = '3.0.17!!'
     tomcatVersion = '9.0.73!!'


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.