### PR TITLE
CCD-4969: bumped spring-security.version to v5.7.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencyCheck {
 ext['elasticsearch.version'] = '7.17.1'
 ext['javax-validation.version'] = '2.0.1.Final'
 ext['hibernate-validator.version'] = '6.0.20.Final'
-ext['spring-security.version'] = '5.7.8'
+ext['spring-security.version'] = '5.7.10'
 ext['jackson.version'] = '2.15.3'
 ext['snakeyaml.version'] = '2.0'
 ext['postgresql.version'] = '42.5.1'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -4,21 +4,19 @@
         CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
         CVE-2023-20883 refer [Ticket]
         CVE-2023-2976  refer [Ticket]
-        CVE-2023-34034 refer [Ticket]
         CVE-2023-42794 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
         CVE-2023-45648 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
         CVE-2023-5072 refer [Ticket]
         CVE-2023-35116 refer [Ticket]
-    
         CVE-2023-33202 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]</notes>
+        CVE-2023-6378 refer [Ticket]
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-20883</cve>
-    <cve>CVE-2023-34034</cve>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-42794</cve>
     <cve>CVE-2023-42795</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4969

### Change description ###

bumped spring-security.version to v5.7.10

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
