### PR TITLE
remove befta test framework as a runtime dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,9 +324,6 @@ subprojects { subproject ->
         testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
 
         testImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.21.13'
-
-        implementation group: 'com.github.hmcts', name: 'befta-fw', version: beftaFwVersion
-
         testImplementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
 
         // https://mvnrepository.com/artifact/junit/junit


### PR DESCRIPTION
This is a test framework that shouldn't form part of the deployed application