### PR TITLE
CCD-5468: bumped postgresql to v42.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ allprojects {
             }
         }
 
+        implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.5'
         implementation "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}"
         implementation "org.apache.tomcat.embed:tomcat-embed-el:${tomcatVersion}"
         implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${tomcatVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext['hibernate-validator.version'] = '6.0.20.Final'
 ext['spring-security.version'] = '5.7.10'
 ext['jackson.version'] = '2.16.0'
 ext['snakeyaml.version'] = '2.0'
-ext['postgresql.version'] = '42.5.1'
+ext['postgresql.version'] = '42.5.5'
 //overriding log4j2 default version 2.7 because of vulnerability issues
 ext['log4j2.version'] = '2.17.1'
 
@@ -291,7 +291,7 @@ subprojects { subproject ->
 
         // To avoid compiler warnings about @API annotations in JUnit5 code.
         testImplementation 'org.apiguardian:apiguardian-api:1.0.0'
-        testImplementation "org.postgresql:postgresql:42.5.1"
+        testImplementation "org.postgresql:postgresql:42.5.5"
         testImplementation "org.testcontainers:postgresql:1.17.2"
         testImplementation "org.hamcrest:hamcrest-core:${hamcrestVersion}"
         testImplementation "org.hamcrest:hamcrest-library:${hamcrestVersion}"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -9,7 +9,6 @@
         CVE-2023-34042 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
         CVE-2024-26308 refer [Ticket]
-        CVE-2024-1597 refer [Ticket]
         CVE-2023-1370 refer [Ticket]</notes>
     <cve>CVE-2024-25710</cve>
     <cve>CVE-2022-45688</cve>
@@ -18,7 +17,6 @@
     <cve>CVE-2023-34042</cve>
     <cve>CVE-2023-46589</cve>
     <cve>CVE-2024-26308</cve>
-    <cve>CVE-2024-1597</cve>
     <cve>CVE-2023-1370</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-5468

### Change description ###

bumped postgresql to v42.5.5

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
