### PR TITLE
CCD-5472: Fix CVE-2024-25710 bumped commons-compress to 1.26.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ allprojects {
         implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
         implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
         // Overriding transitive dependency commons-compress due to CVE failures
-        implementation "org.apache.commons:commons-compress:1.21"
+        implementation "org.apache.commons:commons-compress:1.26.0"
         // CVE-2021-28170
         implementation "org.glassfish:jakarta.el:4.0.1"
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2024-25710 refer [Ticket]
         CVE-2023-35116 refer [Ticket]
         CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
         CVE-2023-5072 refer [Ticket]
@@ -11,7 +10,6 @@
         CVE-2024-26308 refer [Ticket]
         CVE-2024-1597 refer [Ticket]
         CVE-2023-1370 refer [Ticket]</notes>
-    <cve>CVE-2024-25710</cve>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-6378</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-5472

### Change description ###

Fix CVE-2024-25710 bumped commons-compress to 1.26.0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
