### PR TITLE
bump befta-fw to 9.2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext['postgresql.version'] = '42.7.3'
 //overriding log4j2 default version 2.7 because of vulnerability issues
 ext['log4j2.version'] = '2.17.1'
 //overriding for easy access to the version for FT testing
-ext['beftaFwVersion'] = '9.2.3'
+ext['beftaFwVersion'] = '9.2.4'
 ext['ccdTestDefinitionVersion'] = '7.25.4'
 // end
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

NA

### Change description ###

9.2.3 is not available in Az Artifacts, bumped to 9.2.4

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
