### PR TITLE
Update Elasticsearch test container to 7.17.23

### DIFF
--- a/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/CcdElasticsearchContainer.java
+++ b/elastic-search-support/src/test/java/uk/gov/hmcts/ccd/definition/store/elastic/CcdElasticsearchContainer.java
@@ -5,7 +5,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 public class CcdElasticsearchContainer extends ElasticsearchContainer {
 
-    private static final String VERSION = "7.17.0";
+    private static final String VERSION = "7.17.23";
     private static CcdElasticsearchContainer container;
 
     private CcdElasticsearchContainer() {


### PR DESCRIPTION
## Summary
- use the 7.17.23 Elasticsearch Testcontainers image which includes an updated JDK
- avoids the cgroup v2 JDK NPE that stops the container on Ubuntu 24.04 agents
- no production code change, only integration test infrastructure

## Testing
- ./gradlew elastic-search-support:test