### PR TITLE
POFCC-226 - allow answers to challenge questions to have a fixed value of NOT_REQUIRED

### DIFF
--- a/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/validation/ChallengeQuestionValidator.java
+++ b/excel-importer/src/main/java/uk/gov/hmcts/ccd/definition/store/excel/validation/ChallengeQuestionValidator.java
@@ -29,6 +29,8 @@ import static java.util.stream.Collectors.groupingBy;
 @Component
 public class ChallengeQuestionValidator {
 
+    static final String ANSWER_FIELD_NOT_REQUIRED = "NOT_REQUIRED_FOR_DECENTRALISED_SERVICE";
+
     private ParseContext parseContext;
     private static final String ANSWER_MAIN_SEPARATOR = ",";
     private static final String ANSWER_FIELD_SEPARATOR = "|";
@@ -122,6 +124,12 @@ public class ChallengeQuestionValidator {
     private void validateAnswer(DefinitionDataItem definitionDataItem, CaseTypeEntity caseTypeEntity) {
         final String answers = definitionDataItem.getString(ColumnName.CHALLENGE_QUESTION_ANSWER_FIELD);
         validateNullValue(answers, ERROR_MESSAGE + " value: answer cannot be null.");
+
+        if (ANSWER_FIELD_NOT_REQUIRED.equals(answers)) {
+            // No need for further validation
+            return;
+        }
+
         final String[] answersRules = answers.split(ANSWER_MAIN_SEPARATOR);
 
         if (answersRules.length > 0 && answersRules.length != 1) {

--- a/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/validation/ChallengeQuestionValidatorTest.java
+++ b/excel-importer/src/test/java/uk/gov/hmcts/ccd/definition/store/excel/validation/ChallengeQuestionValidatorTest.java
@@ -15,6 +15,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -41,6 +42,24 @@ class ChallengeQuestionValidatorTest extends BaseChallengeQuestionTest {
         challengeQuestionValidator = new ChallengeQuestionValidator(
                 challengeQuestionDisplayContextParameterValidator,
                 new DotNotationValidator());
+    }
+
+    @Test
+    void testAnswerFormatWhenNull() {
+        String answer = null;
+        InvalidImportException exception = assertThrows(InvalidImportException.class,
+            () -> challengeQuestionValidator.validate(parseContext,
+                Lists.newArrayList(buildDefinitionDataItem(CASE_TYPE, FIELD_TYPE, "2",
+                    QUESTION_TEXT, DISPLAY_CONTEXT_PARAMETER_1, QUESTION_ID, answer, "questionId"))));
+        assertEquals("ChallengeQuestionTab Invalid value: answer cannot be null.", exception.getMessage());
+    }
+
+    @Test
+    void testAnswerFormatWhenNotRequired() {
+        String answer = ChallengeQuestionValidator.ANSWER_FIELD_NOT_REQUIRED;
+        challengeQuestionValidator.validate(parseContext,
+                Lists.newArrayList(buildDefinitionDataItem(CASE_TYPE, FIELD_TYPE, "2",
+                    QUESTION_TEXT, DISPLAY_CONTEXT_PARAMETER_1, QUESTION_ID, answer, "questionId")));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/POFCC-226

### Change description ###

Allow answer fields to have a value of `NOT_REQUIRED_FOR_DECENTRALISED_SERVICE` when imported from the CSV spreadsheet.

These are valid answers and are still returned with other answers in the normal way through the API.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
