### PR TITLE
Add provider PACT verification infrastructure and tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -2,6 +2,7 @@
 
 @Library("Infrastructure")
 
+import uk.gov.hmcts.contino.AppPipelineDsl
 import uk.gov.hmcts.contino.GradleBuilder
 
 def type = "java"
@@ -61,18 +62,28 @@ env.BEFTA_RETRY_MAX_DELAY = "1000"
 env.BEFTA_RETRY_NON_RETRYABLE_HTTP_METHODS = "PUT,POST"
 
 env.DEFAULT_COLLECTION_ASSERTION_MODE="UNORDERED"
+env.PACT_BROKER_FULL_URL = "https://pact-broker.platform.hmcts.net"
+env.PACT_BROKER_URL = "pact-broker.platform.hmcts.net"
+env.PACT_BROKER_PORT = "443"
+env.PACT_BROKER_SCHEME = "https"
 // Prevent Docker hub rate limit errors by ensuring that testcontainers uses images from hmctsprod ACR
 env.TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX = "hmctsprod.azurecr.io/imported/"
 
 withPipeline(type, product, app) {
     onMaster {
         enableSlackNotifications('#ccd-master-builds')
+        enablePactAs([
+            AppPipelineDsl.PactRoles.PROVIDER
+        ])
     }
     onDemo {
         enableSlackNotifications('#ccd-demo-builds')
     }
     onPR {
         enableSlackNotifications('#ccd-pr-builds')
+        enablePactAs([
+            AppPipelineDsl.PactRoles.PROVIDER
+        ])
     }
 
     if (env.BRANCH_NAME.startsWith("PR-")) {

--- a/build.gradle
+++ b/build.gradle
@@ -629,3 +629,41 @@ void loadEnvSecrets(String env) {
         }
     }
 }
+
+// Provider PACT verification (consumer contracts published against the definition store)
+sourceSets {
+    contractTest {
+        java {
+            srcDir('src/contractTest/java')
+        }
+        resources {
+            srcDir('src/contractTest/resources')
+        }
+    }
+}
+
+configurations {
+    contractTestImplementation.extendsFrom(testImplementation)
+    contractTestRuntimeOnly.extendsFrom(testRuntimeOnly)
+}
+
+dependencies {
+    contractTestImplementation project(':rest-api')
+    contractTestImplementation project(':domain')
+    contractTestImplementation project(':repository')
+    contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5', version: '4.7.1'
+    contractTestImplementation group: 'au.com.dius.pact.provider', name: 'spring', version: '4.7.1'
+    contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5spring', version: '4.7.1'
+}
+
+task runProviderPactVerification(type: Test) {
+    description = 'Runs provider pact verification against consumer contracts from the broker'
+    group = 'Verification'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.contractTest.output.classesDirs
+    classpath = sourceSets.contractTest.runtimeClasspath
+    if (project.hasProperty('pact.verifier.publishResults')) {
+        systemProperty 'pact.verifier.publishResults', project.property('pact.verifier.publishResults')
+    }
+    systemProperty 'pact.provider.version', project.findProperty('pact.provider.version') ?: 'local'
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/AccessTypesProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/AccessTypesProviderTest.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.ccd.definition.store.rest.endpoint;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.definition.store.rest.service.AccessTypesService;
+
+/**
+ * Provider PACT verification for POST /retrieve-access-types (AccessTypesController). The most
+ * likely future consumer is rpx-xui-manage-organisations, which calls this endpoint at runtime.
+ *
+ * <p>No consumer currently publishes a contract under this provider name; the test is
+ * forward-ready and passes via {@literal @}IgnoreNoPactsToVerify until one appears.</p>
+ */
+@Provider("ccdDefinitionStoreAPI_accessTypes")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class AccessTypesProviderTest {
+
+    @Mock
+    private AccessTypesService accessTypesService;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new AccessTypesController(accessTypesService));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+
+    @State("Access types exist for organisation profiles")
+    public void accessTypesExist() {
+        // State setup (mock accessTypesService) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/BaseTypeProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/BaseTypeProviderTest.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.ccd.definition.store.rest.endpoint;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.definition.store.domain.service.EntityToResponseDTOMapper;
+import uk.gov.hmcts.ccd.definition.store.repository.FieldTypeRepository;
+
+/**
+ * Provider PACT verification for GET /api/base-types (BaseTypeController).
+ *
+ * <p>No consumer currently publishes a contract under this provider name; the test is
+ * forward-ready and passes via {@literal @}IgnoreNoPactsToVerify until one appears.</p>
+ */
+@Provider("ccdDefinitionStoreAPI_baseTypes")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class BaseTypeProviderTest {
+
+    @Mock
+    private FieldTypeRepository fieldTypeRepository;
+
+    @Mock
+    private EntityToResponseDTOMapper entityToResponseDTOMapper;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new BaseTypeController(fieldTypeRepository, entityToResponseDTOMapper));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+
+    @State("Base types exist")
+    public void baseTypesExist() {
+        // State setup (mock fieldTypeRepository) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/CaseDefinitionProviderTest.java
@@ -1,0 +1,83 @@
+package uk.gov.hmcts.ccd.definition.store.rest.endpoint;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.definition.store.domain.service.CaseRoleService;
+import uk.gov.hmcts.ccd.definition.store.domain.service.JurisdictionService;
+import uk.gov.hmcts.ccd.definition.store.domain.service.accessprofiles.RoleToAccessProfileService;
+import uk.gov.hmcts.ccd.definition.store.domain.service.casetype.CaseTypeService;
+
+/**
+ * Provider PACT verification for the case definition data endpoints (CaseDefinitionController):
+ * case type schema, jurisdictions, case types by jurisdiction, case roles and access profiles.
+ *
+ * <p>No consumer currently publishes a contract under this provider name; the test is
+ * forward-ready and passes via {@literal @}IgnoreNoPactsToVerify until one appears.</p>
+ */
+@Provider("ccdDefinitionStoreAPI_caseDefinition")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class CaseDefinitionProviderTest {
+
+    @Mock
+    private CaseTypeService caseTypeService;
+
+    @Mock
+    private JurisdictionService jurisdictionService;
+
+    @Mock
+    private CaseRoleService caseRoleService;
+
+    @Mock
+    private RoleToAccessProfileService roleToAccessProfilesService;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new CaseDefinitionController(caseTypeService, jurisdictionService, caseRoleService,
+            roleToAccessProfilesService));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+
+    @State("A case type schema exists")
+    public void caseTypeSchemaExists() {
+        // State setup (mock caseTypeService) to be completed when a consumer contract is published.
+    }
+
+    @State("Case roles exist for a case type")
+    public void caseRolesExist() {
+        // State setup (mock caseRoleService) to be completed when a consumer contract is published.
+    }
+
+    @State("Jurisdictions exist")
+    public void jurisdictionsExist() {
+        // State setup (mock jurisdictionService) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/DisplayApiProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/DisplayApiProviderTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.ccd.definition.store.rest.endpoint;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.definition.store.domain.service.JurisdictionUiConfigService;
+import uk.gov.hmcts.ccd.definition.store.domain.service.banner.BannerService;
+import uk.gov.hmcts.ccd.definition.store.domain.service.display.DisplayService;
+import uk.gov.hmcts.ccd.definition.store.domain.service.question.ChallengeQuestionTabService;
+
+/**
+ * Provider PACT verification for the display endpoints (DisplayApiController): search/work-basket
+ * input definitions, tab structures, banners, jurisdiction UI configs and challenge questions.
+ *
+ * <p>No consumer currently publishes a contract under this provider name; the test is
+ * forward-ready and passes via {@literal @}IgnoreNoPactsToVerify until one appears.</p>
+ */
+@Provider("ccdDefinitionStoreAPI_display")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class DisplayApiProviderTest {
+
+    @Mock
+    private DisplayService displayService;
+
+    @Mock
+    private BannerService bannerService;
+
+    @Mock
+    private JurisdictionUiConfigService jurisdictionUiConfigService;
+
+    @Mock
+    private ChallengeQuestionTabService challengeQuestionTabService;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new DisplayApiController(displayService, bannerService, jurisdictionUiConfigService,
+            challengeQuestionTabService));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+
+    @State("A UI definition is requested for a case type")
+    public void uiDefinitionRequested() {
+        // State setup (mock displayService) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/DraftDefinitionProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/DraftDefinitionProviderTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.ccd.definition.store.rest.endpoint;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.definition.store.domain.service.DefinitionService;
+
+/**
+ * Provider PACT verification for the draft definition endpoints (DraftDefinitionController).
+ *
+ * <p>No consumer currently publishes a contract under this provider name; the test is
+ * forward-ready and passes via {@literal @}IgnoreNoPactsToVerify until one appears.</p>
+ */
+@Provider("ccdDefinitionStoreAPI_drafts")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class DraftDefinitionProviderTest {
+
+    @Mock
+    private DefinitionService definitionService;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new DraftDefinitionController(definitionService));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+
+    @State("A draft definition exists")
+    public void draftDefinitionExists() {
+        // State setup (mock definitionService) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/ImportAuditProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/ImportAuditProviderTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.ccd.definition.store.rest.endpoint;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.definition.store.rest.service.AzureImportAuditsClient;
+
+/**
+ * Provider PACT verification for GET /api/import-audits (ImportAuditController).
+ *
+ * <p>No consumer currently publishes a contract under this provider name; the test is
+ * forward-ready and passes via {@literal @}IgnoreNoPactsToVerify until one appears.</p>
+ */
+@Provider("ccdDefinitionStoreAPI_importAudits")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class ImportAuditProviderTest {
+
+    @Mock
+    private AzureImportAuditsClient azureImportAuditsClient;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new ImportAuditController(azureImportAuditsClient));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+
+    @State("Import audits exist")
+    public void importAuditsExist() {
+        // State setup (mock azureImportAuditsClient) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/UserRoleProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/definition/store/rest/endpoint/UserRoleProviderTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.ccd.definition.store.rest.endpoint;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.definition.store.domain.service.AccessProfileService;
+
+/**
+ * Provider PACT verification for the user role / access profile endpoints (UserRoleController).
+ *
+ * <p>No consumer currently publishes a contract under this provider name; the test is
+ * forward-ready and passes via {@literal @}IgnoreNoPactsToVerify until one appears.</p>
+ */
+@Provider("ccdDefinitionStoreAPI_userRoles")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class UserRoleProviderTest {
+
+    @Mock
+    private AccessProfileService accessProfileService;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new UserRoleController(accessProfileService));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+
+    @State("A user role exists")
+    public void userRoleExists() {
+        // State setup (mock accessProfileService) to be completed when a consumer contract is published.
+    }
+}


### PR DESCRIPTION
The definition store had no contract-test setup and no provider verification. This adds:
 - a contractTest source set with pact-jvm 4.7.1 and a runProviderPactVerification task in the rest-api module
 - the PROVIDER pact role and broker URLs in Jenkinsfile_CNP
 - provider tests for all seven REST controllers (case definition, display, base types, user roles, access types, import audits, drafts), using the standalone MockMvcTestTarget pattern established in ccd-data-store-api

No consumer currently publishes a contract against the definition store (verified via org-wide code search), so every test carries @IgnoreNoPactsToVerify and provider-state stubs: the suite stays green now and starts verifying automatically as soon as a consumer publishes a pact.

Verified locally against a real empty pact broker on :9292 - all 7 tests pass on the same code path that runs in CI.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] the `keep-helm` label has been added, if the helm release should be persisted after a successful build

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
