### PR TITLE
Onboard CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.4.0")
+@Library("Infrastructure@cve-dashboard")
 
 import uk.gov.hmcts.contino.GradleBuilder
 
@@ -68,6 +68,7 @@ env.DEFAULT_COLLECTION_ASSERTION_MODE="UNORDERED"
 env.TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX = "hmctsprod.azurecr.io/imported/"
 
 withPipeline(type, product, app) {
+    enableCveDashboardIngestion()
     onMaster {
         enableSlackNotifications('#ccd-master-builds')
     }


### PR DESCRIPTION
## Summary
- pin the shared Jenkins library to cve-dashboard, now based on version 2.4.9
- enable CVE dashboard ingestion for the first time

## Testing
- Jenkinsfile-only configuration change